### PR TITLE
feat(staking): wire staking balances into the yield engine

### DIFF
--- a/contracts/staking/src/engine.rs
+++ b/contracts/staking/src/engine.rs
@@ -87,6 +87,32 @@ impl<'a> YieldEngine<'a> {
         Ok(updated)
     }
 
+    /// Adjust the principal of an existing position to `new_principal`,
+    /// preserving its APR, compounding mode, and realized `accrued_yield`.
+    ///
+    /// The position is checkpointed (accrued to now) *before* the principal
+    /// changes, so all yield earned on the old principal is realized and no yield
+    /// is lost across the boundary. This is what stake/unstake use to keep a
+    /// position's principal equal to the staked balance without resetting its
+    /// rate.
+    pub fn set_principal(
+        &self,
+        staker: &Address,
+        asset: &Symbol,
+        new_principal: i128,
+    ) -> Result<YieldRecord, MathError> {
+        let now = self.env.ledger().timestamp();
+        let record = self
+            .load_record(staker, asset)
+            .ok_or(MathError::NegativeInput)?;
+        // Realize everything earned on the old principal first.
+        let mut updated = self.accrue_to(&record, now)?;
+        // Then move principal going forward.
+        updated.principal = new_principal;
+        self.store_record(&updated);
+        Ok(updated)
+    }
+
     /// Change the APR for a position, checkpointing accrued yield at the old rate
     /// first so the transition is exact and time-weighted.
     pub fn set_rate(

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -29,10 +29,17 @@ pub mod records;
 
 use crate::apy::APYCalculator;
 use crate::engine::YieldEngine;
+use crate::fixed_point::SCALE;
 use crate::projection::YieldProjector;
 use crate::records::{
-    CompoundingMode, DistributionSchedule, YieldHistoryEntry, YieldProjection, YieldRecord,
+    CompoundingMode, DistributionSchedule, StakeDataKey, StakingConfig, YieldHistoryEntry,
+    YieldProjection, YieldRecord,
 };
+
+/// Default APR seeded onto a newly opened yield position: 5% (fixed-point).
+const DEFAULT_APR: i128 = SCALE / 20;
+/// Default compounding mode seeded onto a newly opened yield position.
+const DEFAULT_MODE: CompoundingMode = CompoundingMode::Daily;
 
 /// Staking contract for AstraPort
 /// Manages staking operations, alert functionality, and yield calculation.
@@ -52,42 +59,96 @@ impl StakingContract {
         symbol_short!("ok")
     }
 
-    /// Stake assets into the contract
+    /// Stake `amount` of `asset` for `staker`, wiring the deposit into the yield
+    /// engine so the position's principal always equals the staked balance.
     ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `staker` - Address of the staker
-    /// * `amount` - Amount to stake
+    /// If this is the first stake for the pair, a yield position is opened at the
+    /// configured default APR / compounding mode (see [`Self::set_yield_defaults`]).
+    /// If a position already exists, it is checkpointed (accrued to now) and its
+    /// principal raised to the new balance, preserving both its rate/mode and any
+    /// realized yield.
     ///
     /// # Returns
-    /// Success symbol if staking succeeds
-    pub fn stake(_env: Env, _staker: Symbol, _amount: i128) -> Symbol {
-        symbol_short!("done")
+    /// The staker's new staked balance for the asset.
+    pub fn stake(env: Env, staker: Address, asset: Symbol, amount: i128) -> i128 {
+        if amount <= 0 {
+            panic!("stake amount must be positive");
+        }
+        let new_balance = Self::balance_of(&env, &staker, &asset)
+            .checked_add(amount)
+            .expect("stake balance overflow");
+
+        let engine = YieldEngine::new(&env);
+        match engine.load_record(&staker, &asset) {
+            // Existing position: checkpoint, then raise principal (keeps its rate).
+            Some(_) => {
+                engine
+                    .set_principal(&staker, &asset, new_balance)
+                    .expect("failed to adjust yield principal on stake");
+            }
+            // First stake: open a position seeded with the default parameters.
+            None => {
+                let config = Self::load_config(&env);
+                engine
+                    .open_position(
+                        &staker,
+                        &asset,
+                        new_balance,
+                        config.default_apr,
+                        config.default_mode,
+                    )
+                    .expect("failed to open yield position on stake");
+            }
+        }
+
+        Self::set_balance(&env, &staker, &asset, new_balance);
+        new_balance
     }
 
-    /// Unstake assets from the contract
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `staker` - Address of the staker
-    /// * `amount` - Amount to unstake
+    /// Unstake `amount` of `asset` for `staker`, checkpointing accrued yield
+    /// before reducing the position's principal so no earned yield is lost.
     ///
     /// # Returns
-    /// Success symbol if unstaking succeeds
-    pub fn unstake(_env: Env, _staker: Symbol, _amount: i128) -> Symbol {
-        symbol_short!("done")
+    /// The staker's remaining staked balance for the asset.
+    pub fn unstake(env: Env, staker: Address, asset: Symbol, amount: i128) -> i128 {
+        let current = Self::balance_of(&env, &staker, &asset);
+        if amount <= 0 || amount > current {
+            panic!("invalid unstake amount");
+        }
+        let new_balance = current - amount;
+
+        // set_principal accrues (checkpoints) at the current rate *before* the
+        // principal drops, so realized yield is preserved.
+        YieldEngine::new(&env)
+            .set_principal(&staker, &asset, new_balance)
+            .expect("failed to adjust yield principal on unstake");
+
+        Self::set_balance(&env, &staker, &asset, new_balance);
+        new_balance
     }
 
-    /// Get staking balance for an address
+    /// Get the staked balance for a `(staker, asset)` pair.
+    pub fn get_balance(env: Env, staker: Address, asset: Symbol) -> i128 {
+        Self::balance_of(&env, &staker, &asset)
+    }
+
+    /// Configure the default APR and compounding mode used when a new yield
+    /// position is opened by the first [`Self::stake`] for a pair.
     ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `staker` - Address of the staker
+    /// Existing positions are unaffected; change an open position's rate with
+    /// [`Self::set_yield_rate`] instead.
     ///
     /// # Returns
-    /// Current staking balance
-    pub fn get_balance(_env: Env, _staker: Symbol) -> i128 {
-        0
+    /// The stored [`StakingConfig`].
+    pub fn set_yield_defaults(env: Env, apr: i128, mode: CompoundingMode) -> StakingConfig {
+        let config = StakingConfig {
+            default_apr: apr,
+            default_mode: mode,
+        };
+        env.storage()
+            .persistent()
+            .set(&StakeDataKey::Config, &config);
+        config
     }
 
     /// Set alert threshold for staking changes
@@ -226,6 +287,37 @@ impl StakingContract {
     /// time, returning the total amount that became due.
     pub fn process_distribution(env: Env, staker: Address, asset: Symbol) -> i128 {
         YieldEngine::new(&env).process_distribution(&staker, &asset)
+    }
+}
+
+/// Internal helpers (not part of the contract's external interface).
+impl StakingContract {
+    /// Read the staked balance for a pair, defaulting to `0`.
+    fn balance_of(env: &Env, staker: &Address, asset: &Symbol) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&StakeDataKey::Balance(staker.clone(), asset.clone()))
+            .unwrap_or(0)
+    }
+
+    /// Persist the staked balance for a pair.
+    fn set_balance(env: &Env, staker: &Address, asset: &Symbol, balance: i128) {
+        env.storage().persistent().set(
+            &StakeDataKey::Balance(staker.clone(), asset.clone()),
+            &balance,
+        );
+    }
+
+    /// Load the configured yield defaults, falling back to the built-in
+    /// [`DEFAULT_APR`] / [`DEFAULT_MODE`] when unset.
+    fn load_config(env: &Env) -> StakingConfig {
+        env.storage()
+            .persistent()
+            .get(&StakeDataKey::Config)
+            .unwrap_or(StakingConfig {
+                default_apr: DEFAULT_APR,
+                default_mode: DEFAULT_MODE,
+            })
     }
 }
 

--- a/contracts/staking/src/records.rs
+++ b/contracts/staking/src/records.rs
@@ -134,3 +134,28 @@ pub enum YieldDataKey {
     /// The [`DistributionSchedule`] list for a `(staker, asset)` pair.
     Schedule(Address, Symbol),
 }
+
+/// Default yield parameters applied when a position is first opened by a stake.
+///
+/// A single position, once opened, keeps its own APR and compounding mode across
+/// subsequent stakes/unstakes (which only adjust principal); these defaults seed
+/// brand-new positions and can be reconfigured before the first stake.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct StakingConfig {
+    /// APR seeded onto a newly opened yield position, fixed-point (see
+    /// [`crate::fixed_point::SCALE`]).
+    pub default_apr: i128,
+    /// Compounding mode seeded onto a newly opened yield position.
+    pub default_mode: CompoundingMode,
+}
+
+/// Storage keys for the staking layer that sits in front of the yield engine.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub enum StakeDataKey {
+    /// Staked balance (principal) for a `(staker, asset)` pair, base units.
+    Balance(Address, Symbol),
+    /// The default [`StakingConfig`] used when opening new positions.
+    Config,
+}

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -28,9 +28,10 @@ fn test_initialize() {
 
 #[test]
 fn test_get_balance() {
-    let env = Env::default();
-    let result = StakingContract::get_balance(env, symbol_short!("user"));
-    assert_eq!(result, 0);
+    let (env, client) = setup();
+    let staker = Address::generate(&env);
+    // A pair with no stake reports a zero balance.
+    assert_eq!(client.get_balance(&staker, &symbol_short!("XLM")), 0);
 }
 
 // --- helpers --------------------------------------------------------------
@@ -249,6 +250,104 @@ fn apy_apr_roundtrip_via_contract() {
     let back = client.apy_to_apr(&apy, &CompoundingMode::Daily);
     // within 0.01% -> tol 1e14 on 1e18 scale
     approx(back, apr, 100_000_000_000_000);
+}
+
+#[test]
+fn stake_opens_position_and_accrues_on_staked_principal() {
+    let (env, client) = setup();
+    env.ledger().set_timestamp(0);
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    // Staking wires the deposit into the yield engine at the default params
+    // (5% APR, daily), and the returned/queried balance reflects the stake.
+    let balance = client.stake(&staker, &asset, &SCALE);
+    assert_eq!(balance, SCALE);
+    assert_eq!(client.get_balance(&staker, &asset), SCALE);
+
+    // Yield accrues on the actual staked principal.
+    env.ledger().set_timestamp(SECONDS_PER_YEAR);
+    let yielded = client.current_yield(&staker, &asset);
+    // (1 + 0.05/365)^365 - 1 on 1e18 ~= 5.1267e16
+    approx(yielded, 51_267_496_505_408_400, 100_000_000_000);
+}
+
+#[test]
+fn additional_stake_raises_principal_and_keeps_yield() {
+    let (env, client) = setup();
+    env.ledger().set_timestamp(0);
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.stake(&staker, &asset, &SCALE);
+
+    // After a year, stake more. This must checkpoint accrued yield first.
+    env.ledger().set_timestamp(SECONDS_PER_YEAR);
+    let new_balance = client.stake(&staker, &asset, &SCALE);
+    assert_eq!(new_balance, 2 * SCALE);
+
+    // Principal now equals the staked balance; realized yield is preserved.
+    let rec = client.accrue_yield(&staker, &asset);
+    assert_eq!(rec.principal, 2 * SCALE);
+    approx(rec.accrued_yield, 51_267_496_505_408_400, 100_000_000_000);
+}
+
+#[test]
+fn unstake_preserves_accrued_yield_and_reduces_principal() {
+    let (env, client) = setup();
+    env.ledger().set_timestamp(0);
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    // Stake 1e18 and let a full year of yield accrue.
+    client.stake(&staker, &asset, &SCALE);
+    env.ledger().set_timestamp(SECONDS_PER_YEAR);
+    let expected_yield = 51_267_496_505_408_400i128; // 5% daily on 1e18
+
+    // Unstake half. This checkpoints accrued yield before dropping principal.
+    let remaining = client.unstake(&staker, &asset, &(SCALE / 2));
+    assert_eq!(remaining, SCALE / 2);
+    assert_eq!(client.get_balance(&staker, &asset), SCALE / 2);
+
+    // Accrued yield is preserved and principal is reduced (accrue at the same
+    // timestamp is a no-op, so it just returns the stored record).
+    let rec = client.accrue_yield(&staker, &asset);
+    assert_eq!(rec.principal, SCALE / 2);
+    approx(rec.accrued_yield, expected_yield, 100_000_000_000);
+
+    // Going forward, further yield accrues on the reduced principal on top of
+    // the preserved amount.
+    env.ledger().set_timestamp(2 * SECONDS_PER_YEAR);
+    let total = client.current_yield(&staker, &asset);
+    // preserved + second-year yield on half the principal (~2.5634e16).
+    approx(total, expected_yield + 25_633_748_252_704_200, 100_000_000_000);
+}
+
+#[test]
+fn configured_yield_defaults_apply_to_new_positions() {
+    let (env, client) = setup();
+    env.ledger().set_timestamp(0);
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("USDC");
+
+    // Reconfigure defaults to 10% continuous before the first stake.
+    client.set_yield_defaults(&(SCALE / 10), &CompoundingMode::Continuous);
+    client.stake(&staker, &asset, &SCALE);
+
+    env.ledger().set_timestamp(SECONDS_PER_YEAR / 2);
+    let mid = client.current_yield(&staker, &asset);
+    // e^(0.1*0.5) - 1 = e^0.05 - 1 on 1e18
+    approx(mid, 51_271_096_376_024_040, 100_000_000_000);
+}
+
+#[test]
+#[should_panic(expected = "invalid unstake amount")]
+fn unstake_more_than_staked_panics() {
+    let (env, client) = setup();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+    client.stake(&staker, &asset, &SCALE);
+    client.unstake(&staker, &asset, &(SCALE + 1));
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,9 +35,10 @@ AstraPort Smart Contracts is a suite of Soroban-based smart contracts built on t
 - **Purpose**: Manages staking operations, alerts, and yield calculation
 - **Key Functions**:
   - `initialize()` - Initialize the contract
-  - `stake()` - Stake assets
-  - `unstake()` - Unstake assets
-  - `get_balance()` - Query staking balance
+  - `stake()` - Stake assets; opens or grows the staker/asset yield position so its principal tracks the staked balance
+  - `unstake()` - Unstake assets; checkpoints accrued yield before reducing principal so no yield is lost
+  - `get_balance()` - Query the staked balance for a staker/asset pair
+  - `set_yield_defaults()` - Configure the default APR and compounding mode seeded onto newly opened positions
   - `set_alert_threshold()` - Configure alert thresholds
 - **Yield Engine Functions**:
   - `open_yield_position()` - Start accruing yield for a staker/asset at a given APR and compounding mode


### PR DESCRIPTION
Closes #15

## Summary

`YieldEngine` tracked positions independently of the staked balance. This PR makes a real deposit open/adjust a yield position automatically so a position's **principal always equals the staked capital** for a `(staker, asset)` pair.

## Changes

- **`stake`**: now maintains a per-`(staker, asset)` staked balance and wires it into the yield engine.
  - First deposit → `open_position` at the configured default APR / compounding mode.
  - Subsequent deposits → checkpoint (accrue to now) then raise principal via the new `set_principal`, **preserving the position's rate/mode and realized yield** (so a prior `set_yield_rate` isn't clobbered).
- **`unstake`**: checkpoints accrued yield at the current rate **before** reducing principal, so no earned yield is lost.
- **`YieldEngine::set_principal`**: accrue-then-adjust helper that changes principal while preserving APR, mode, and `accrued_yield`.
- **Configurable defaults**: `set_yield_defaults(apr, mode)` sets the params seeded onto newly opened positions; falls back to 5% daily when unset.
- **API**: `stake`/`unstake`/`get_balance` now key on `(Address, Symbol asset)` to match the yield engine (the previous stubs used a bare `Symbol` and no asset).

## Acceptance criteria

- ✅ After stake, `current_yield` accrues on the actual staked principal.
- ✅ `unstake` checkpoints accrued yield before reducing principal (no yield lost).
- ✅ Test: stake → advance ledger time → unstake → asserts accrued yield preserved and principal reduced (`unstake_preserves_accrued_yield_and_reduces_principal`).
- ✅ `cargo test -p astraport-staking` passes (41 tests).

## Tests added

- `stake_opens_position_and_accrues_on_staked_principal`
- `additional_stake_raises_principal_and_keeps_yield`
- `unstake_preserves_accrued_yield_and_reduces_principal`
- `configured_yield_defaults_apply_to_new_positions`
- `unstake_more_than_staked_panics`