### PR TITLE
feat(staking): add authentication to staking mutations

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -31,7 +31,8 @@ use crate::apy::APYCalculator;
 use crate::engine::YieldEngine;
 use crate::projection::YieldProjector;
 use crate::records::{
-    CompoundingMode, DistributionSchedule, YieldHistoryEntry, YieldProjection, YieldRecord,
+    CompoundingMode, DistributionSchedule, YieldDataKey, YieldHistoryEntry, YieldProjection,
+    YieldRecord,
 };
 
 /// Staking contract for AstraPort
@@ -41,18 +42,28 @@ pub struct StakingContract;
 
 #[contractimpl]
 impl StakingContract {
-    /// Initialize the staking contract
+    /// Initialize the staking contract with an admin.
+    ///
+    /// Can only be called once; subsequent calls will panic.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
+    /// * `admin` - The admin address to store
     ///
     /// # Returns
     /// Success symbol if initialization succeeds
-    pub fn initialize(_env: Env) -> Symbol {
+    pub fn initialize(env: Env, admin: Address) -> Symbol {
+        let storage = env.storage().persistent();
+        if storage.has(&YieldDataKey::Admin) {
+            panic!("already initialized");
+        }
+        storage.set(&YieldDataKey::Admin, &admin);
         symbol_short!("ok")
     }
 
-    /// Stake assets into the contract
+    /// Stake assets into the contract.
+    ///
+    /// Requires authorization from the staker.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -61,11 +72,17 @@ impl StakingContract {
     ///
     /// # Returns
     /// Success symbol if staking succeeds
-    pub fn stake(_env: Env, _staker: Symbol, _amount: i128) -> Symbol {
+    pub fn stake(env: Env, staker: Address, amount: i128) -> Symbol {
+        staker.require_auth();
+        let key = YieldDataKey::Balance(staker.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
         symbol_short!("done")
     }
 
-    /// Unstake assets from the contract
+    /// Unstake assets from the contract.
+    ///
+    /// Requires authorization from the staker.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -74,11 +91,16 @@ impl StakingContract {
     ///
     /// # Returns
     /// Success symbol if unstaking succeeds
-    pub fn unstake(_env: Env, _staker: Symbol, _amount: i128) -> Symbol {
+    pub fn unstake(env: Env, staker: Address, amount: i128) -> Symbol {
+        staker.require_auth();
+        let key = YieldDataKey::Balance(staker.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        assert!(current >= amount, "insufficient balance");
+        env.storage().persistent().set(&key, &(current - amount));
         symbol_short!("done")
     }
 
-    /// Get staking balance for an address
+    /// Get staking balance for an address.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -86,19 +108,33 @@ impl StakingContract {
     ///
     /// # Returns
     /// Current staking balance
-    pub fn get_balance(_env: Env, _staker: Symbol) -> i128 {
-        0
+    pub fn get_balance(env: Env, staker: Address) -> i128 {
+        let key = YieldDataKey::Balance(staker);
+        env.storage().persistent().get(&key).unwrap_or(0)
     }
 
-    /// Set alert threshold for staking changes
+    /// Set alert threshold for staking changes.
+    ///
+    /// Only callable by the admin set during `initialize`.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
+    /// * `admin` - The admin address (must match the stored admin)
     /// * `threshold` - Alert threshold amount
     ///
     /// # Returns
     /// Success symbol if alert threshold is set
-    pub fn set_alert_threshold(_env: Env, _threshold: i128) -> Symbol {
+    pub fn set_alert_threshold(env: Env, admin: Address, threshold: i128) -> Symbol {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&YieldDataKey::Admin)
+            .expect("contract not initialized");
+        assert!(stored_admin == admin, "caller is not admin");
+        env.storage()
+            .persistent()
+            .set(&YieldDataKey::AlertThreshold, &threshold);
         symbol_short!("ok")
     }
 

--- a/contracts/staking/src/records.rs
+++ b/contracts/staking/src/records.rs
@@ -133,4 +133,10 @@ pub enum YieldDataKey {
     History(Address, Symbol),
     /// The [`DistributionSchedule`] list for a `(staker, asset)` pair.
     Schedule(Address, Symbol),
+    /// The contract admin address set during `initialize`.
+    Admin,
+    /// The staked balance for an address.
+    Balance(Address),
+    /// The alert threshold value.
+    AlertThreshold,
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -15,21 +15,58 @@ use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{symbol_short, Address, Env};
 
 use crate::fixed_point::{SCALE, SECONDS_PER_DAY, SECONDS_PER_YEAR};
-use crate::records::CompoundingMode;
+use crate::records::{CompoundingMode, YieldDataKey};
 
 // --- original smoke tests -------------------------------------------------
 
 #[test]
 fn test_initialize() {
     let env = Env::default();
-    let result = StakingContract::initialize(env);
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let result = client.initialize(&admin);
     assert_eq!(result, symbol_short!("ok"));
+}
+
+#[test]
+fn test_initialize_stores_admin() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    env.as_contract(&contract_id, || {
+        let stored: Address = env
+            .storage()
+            .persistent()
+            .get(&YieldDataKey::Admin)
+            .unwrap();
+        assert_eq!(stored, admin);
+    });
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_cannot_reinitialize() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    let other_admin = Address::generate(&env);
+    client.initialize(&other_admin);
 }
 
 #[test]
 fn test_get_balance() {
     let env = Env::default();
-    let result = StakingContract::get_balance(env, symbol_short!("user"));
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    let staker = Address::generate(&env);
+    let result = client.get_balance(&staker);
     assert_eq!(result, 0);
 }
 
@@ -47,6 +84,139 @@ fn setup() -> (Env, StakingContractClient<'static>) {
 fn approx(a: i128, b: i128, tol: i128) {
     let diff = (a - b).abs();
     assert!(diff <= tol, "expected {} ~= {} within {}, diff {}", a, b, tol, diff);
+}
+
+// --- authentication tests --------------------------------------------------
+
+#[test]
+fn test_stake_requires_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    client.stake(&staker, &1_000);
+    assert_eq!(client.get_balance(&staker), 1_000);
+}
+
+#[test]
+#[should_panic]
+fn test_stake_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    // No mock_auths — require_auth will fail
+    client.stake(&staker, &1_000);
+}
+
+#[test]
+fn test_unstake_requires_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    client.stake(&staker, &1_000);
+    client.unstake(&staker, &500);
+    assert_eq!(client.get_balance(&staker), 500);
+}
+
+#[test]
+#[should_panic]
+fn test_unstake_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    env.mock_all_auths();
+    client.stake(&staker, &1_000);
+
+    // Create a fresh env without auth mocking
+    let env2 = Env::default();
+    let contract_id2 = env2.register_contract(None, StakingContract);
+    let client2 = StakingContractClient::new(&env2, &contract_id2);
+    let admin2 = Address::generate(&env2);
+    client2.initialize(&admin2);
+    let staker2 = Address::generate(&env2);
+    // No mock_auths — should panic
+    client2.unstake(&staker2, &500);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_unstake_insufficient_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    client.stake(&staker, &100);
+    client.unstake(&staker, &200);
+}
+
+#[test]
+fn test_stake_updates_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let staker = Address::generate(&env);
+    assert_eq!(client.get_balance(&staker), 0);
+
+    client.stake(&staker, &1_000);
+    assert_eq!(client.get_balance(&staker), 1_000);
+
+    client.stake(&staker, &500);
+    assert_eq!(client.get_balance(&staker), 1_500);
+
+    client.unstake(&staker, &200);
+    assert_eq!(client.get_balance(&staker), 1_300);
+}
+
+#[test]
+fn test_set_alert_threshold_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_alert_threshold(&admin, &10_000);
+}
+
+#[test]
+#[should_panic(expected = "caller is not admin")]
+fn test_set_alert_threshold_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let non_admin = Address::generate(&env);
+    // Auth passes (mock_all_auths), but the admin check fails
+    client.set_alert_threshold(&non_admin, &10_000);
 }
 
 // --- yield engine contract tests ------------------------------------------


### PR DESCRIPTION
Closes #16

## Summary
Adds authorization to all staking mutations in `contracts/staking`, following the `require_auth()` pattern already used in the events contract.

## Changes
- `lib.rs`
  - `initialize(admin: Address)` — stores the admin in persistent storage; panics with `"already initialized"` on re-initialization.
  - `stake(staker: Address, amount)` — requires `staker.require_auth()`; tracks per-address staked balance.
  - `unstake(staker: Address, amount)` — requires `staker.require_auth()`; asserts sufficient balance before deducting.
  - `set_alert_threshold(admin: Address, threshold)` — requires admin auth and asserts the caller matches the admin stored at `initialize`.
  - `get_balance(staker: Address)` — returns the real stored balance.
- `records.rs` — new `YieldDataKey` variants: `Admin`, `Balance(Address)`, `AlertThreshold`.
- `tests.rs` — 9 new tests covering authorized and unauthorized paths via `mock_all_auths`.

## Acceptance criteria (issue #16)
- [x] `stake`/`unstake` fail without the staker's authorization (verified with `mock_auths` in tests).
- [x] `set_alert_threshold` succeeds only for the configured admin.
- [x] `initialize` stores the admin and is not re-initializable.
- [x] Tests use `Env::mock_all_auths` / explicit `mock_auths` to cover authorized and unauthorized paths.

## Testing
```
cargo test -p astraport-staking
test result: ok. 46 passed; 0 failed
```