### PR TITLE
Add Emergency Unstaking with Penalty System

### DIFF
--- a/contracts/staking/src/emergency.rs
+++ b/contracts/staking/src/emergency.rs
@@ -1,0 +1,704 @@
+//! Emergency unstaking with penalty system.
+//!
+//! This module implements early withdrawal from a locked stake position before
+//! the scheduled unlock date. Penalties are assessed at the time of withdrawal
+//! and decay over time as the unlock approaches, balancing user flexibility
+//! against protocol incentives.
+//!
+//! # Penalty Decay
+//!
+//! Two decay functions are supported:
+//!
+//! - **Linear**: The penalty decreases uniformly from `penalty_start_bps` at
+//!   lock-start to `penalty_end_bps` at the unlock date.
+//!   `penalty(t) = start + (end - start) * elapsed / total_lock_seconds`
+//!
+//! - **Exponential**: The penalty decreases rapidly early in the lock period and
+//!   slowly near the end, modeled as
+//!   `penalty(t) = start * (end / start)^(elapsed / total_lock_seconds)`.
+//!
+//! All penalty rates are expressed in basis points (1 bp = 0.01%). The range
+//! [0, 10_000] maps to [0%, 100%].
+//!
+//! # Storage Layout
+//!
+//! Emergency unstake data uses [`EmergencyDataKey`] variants:
+//! - `Config` — a single [`EmergencyUnstakeConfig`] per contract.
+//! - `CooldownEnd(Address)` — the ledger timestamp after which a staker may
+//!   emergency-unstake again (0 if no cooldown is active).
+//! - `History(Address)` — append-only `Vec<EmergencyUnstakeRecord>` per staker.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
+
+use crate::fixed_point::{self as fp, MathError, ONE, SCALE};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum allowed basis-point value (= 100%).
+pub const MAX_BPS: i128 = 10_000;
+
+/// The fixed-point representation of 10_000 (basis-point denominator).
+const BPS_SCALE: i128 = 10_000;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Selects how the penalty rate decays toward the unlock date.
+#[contracttype]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PenaltyDecayFunction {
+    /// Penalty decreases linearly from start to end over the full lock period.
+    Linear,
+    /// Penalty decreases exponentially: fast early, slow near the end.
+    Exponential,
+    /// A custom decay that always returns `penalty_start_bps` unchanged.
+    /// Useful for fixed-rate penalty schemes; callers may extend logic here.
+    Custom,
+}
+
+/// Contract-wide configuration for the emergency-unstake system.
+///
+/// Stored under [`EmergencyDataKey::Config`]. All basis-point fields are in
+/// the range [0, 10_000], where 10_000 = 100%.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct EmergencyUnstakeConfig {
+    /// Penalty rate at the *start* of the lock period, in basis points.
+    /// Assessed when `elapsed == 0`.
+    pub penalty_start_bps: i128,
+    /// Penalty rate at the *end* of the lock period (at unlock), in basis
+    /// points. Assessed when `elapsed == total_lock_seconds`.
+    pub penalty_end_bps: i128,
+    /// How the penalty interpolates between start and end.
+    pub decay_function: PenaltyDecayFunction,
+    /// Duration (in seconds) a staker must wait after an emergency unstake
+    /// before they are permitted to do another one.
+    pub cooldown_seconds: u64,
+    /// Treasury address that receives all collected penalties.
+    pub treasury: Address,
+    /// Whether emergency unstaking is currently enabled on this contract.
+    pub enabled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// An immutable record of a single emergency unstake event.
+///
+/// Appended to the staker's history log under [`EmergencyDataKey::History`].
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct EmergencyUnstakeRecord {
+    /// The staker who performed the emergency unstake.
+    pub staker: Address,
+    /// Ledger timestamp (seconds) at which the operation occurred.
+    pub timestamp: u64,
+    /// Principal amount the staker attempted to withdraw.
+    pub amount_requested: i128,
+    /// Penalty amount deducted from `amount_requested`.
+    pub penalty_amount: i128,
+    /// Final amount returned to the staker (`amount_requested - penalty_amount`).
+    pub amount_returned: i128,
+    /// Penalty rate actually applied, in basis points.
+    pub penalty_bps_applied: i128,
+    /// Ledger timestamp when the staker's lock period was originally set to end.
+    pub original_unlock_ts: u64,
+    /// Ledger timestamp when the lock period originally started (= when the
+    /// stake was first locked).
+    pub lock_start_ts: u64,
+    /// Whether this was a partial (true) or full (false) emergency unstake.
+    pub is_partial: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+/// Storage keys for the emergency-unstake subsystem.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub enum EmergencyDataKey {
+    /// The single contract-wide [`EmergencyUnstakeConfig`].
+    Config,
+    /// The ledger timestamp after which `Address` may emergency-unstake again.
+    /// A value of 0 means no cooldown is active.
+    CooldownEnd(Address),
+    /// Append-only `Vec<EmergencyUnstakeRecord>` log for an address.
+    History(Address),
+}
+
+// ---------------------------------------------------------------------------
+// Penalty calculator
+// ---------------------------------------------------------------------------
+
+/// Computes the penalty basis points applicable to an emergency unstake.
+///
+/// # Arguments
+///
+/// * `config` — the active [`EmergencyUnstakeConfig`].
+/// * `elapsed_seconds` — seconds elapsed since the lock was opened.
+/// * `total_lock_seconds` — full intended lock duration in seconds.
+///
+/// Returns basis points in `[penalty_end_bps, penalty_start_bps]`, or an error
+/// if the fixed-point arithmetic overflows.
+pub struct PenaltyCalculator;
+
+impl PenaltyCalculator {
+    /// Compute the penalty in basis points for an emergency unstake.
+    ///
+    /// The result is clamped to `[0, MAX_BPS]`.
+    pub fn compute_penalty_bps(
+        config: &EmergencyUnstakeConfig,
+        elapsed_seconds: u64,
+        total_lock_seconds: u64,
+    ) -> Result<i128, MathError> {
+        // Edge cases: if the lock has not started or there is no lock duration,
+        // apply the start penalty.
+        if total_lock_seconds == 0 || elapsed_seconds == 0 {
+            return Ok(config.penalty_start_bps.min(MAX_BPS));
+        }
+        // If elapsed >= total, the lock has matured — apply end penalty.
+        if elapsed_seconds >= total_lock_seconds {
+            return Ok(config.penalty_end_bps.max(0).min(MAX_BPS));
+        }
+
+        let start = config.penalty_start_bps;
+        let end = config.penalty_end_bps;
+
+        let bps = match config.decay_function {
+            PenaltyDecayFunction::Linear => {
+                Self::linear_decay(start, end, elapsed_seconds, total_lock_seconds)?
+            }
+            PenaltyDecayFunction::Exponential => {
+                Self::exponential_decay(start, end, elapsed_seconds, total_lock_seconds)?
+            }
+            PenaltyDecayFunction::Custom => {
+                // Custom: fixed at start penalty regardless of elapsed time.
+                start
+            }
+        };
+
+        Ok(bps.max(0).min(MAX_BPS))
+    }
+
+    /// Linear interpolation between `start` and `end`.
+    ///
+    /// `bps = start + (end - start) * elapsed / total`
+    fn linear_decay(
+        start: i128,
+        end: i128,
+        elapsed: u64,
+        total: u64,
+    ) -> Result<i128, MathError> {
+        // progress = elapsed / total  (fixed-point)
+        let progress = fp::div(elapsed as i128, total as i128)?;
+        let delta = end - start; // can be negative if end < start (normal case)
+        let change = fp::mul(delta, progress)?;
+        start.checked_add(change).ok_or(MathError::Overflow)
+    }
+
+    /// Exponential decay: `bps = start * (end / start)^(elapsed / total)`.
+    ///
+    /// Computed as `exp(ln(end/start) * (elapsed/total)) * start`.
+    ///
+    /// If `start == 0` or `end == 0` the formula degenerates; we fall back to
+    /// linear in those cases to avoid a `ln(0)` domain error.
+    fn exponential_decay(
+        start: i128,
+        end: i128,
+        elapsed: u64,
+        total: u64,
+    ) -> Result<i128, MathError> {
+        if start <= 0 || end <= 0 {
+            // Degenerate: use linear when one bound is zero.
+            return Self::linear_decay(start, end, elapsed, total);
+        }
+
+        // t = elapsed / total  (fixed-point fraction in [0, 1))
+        let t = fp::div(elapsed as i128, total as i128)?;
+
+        // ratio = end / start  (fixed-point)
+        let start_fp = fp::mul(start, SCALE / BPS_SCALE)?;
+        let end_fp = fp::mul(end, SCALE / BPS_SCALE)?;
+        let ratio = fp::div(end_fp, start_fp)?;
+
+        // ln(ratio) and exponent = ln(ratio) * t
+        // Both start and end are in [0, MAX_BPS]; ratio is in (0, ∞).
+        // If ratio < ONE (normal: end < start) ln is negative, but exp requires
+        // non-negative input. We handle this by working with 1/ratio and
+        // negating afterward.
+        let bps_fp = if ratio >= ONE {
+            // end >= start (unusual, penalty growing over time — still valid)
+            let ln_ratio = crate::apy::ln(ratio)?;
+            let exponent = fp::mul(ln_ratio, t)?;
+            let factor = fp::exp(exponent)?;
+            fp::mul(start_fp, factor)?
+        } else {
+            // end < start (normal decay)
+            let inv_ratio = fp::div(ONE, ratio)?;
+            let ln_inv = crate::apy::ln(inv_ratio)?;
+            let exponent = fp::mul(ln_inv, t)?;
+            let factor = fp::exp(exponent)?;
+            // result = start / factor  (since start * (1/ratio)^t = start / ratio^t)
+            fp::div(start_fp, factor)?
+        };
+
+        // Convert back from fixed-point fraction to basis points.
+        fp::mul(bps_fp, BPS_SCALE * ONE / SCALE)
+    }
+
+    /// Apply a penalty in basis points to an amount.
+    ///
+    /// Returns `(penalty_amount, net_amount)`.
+    pub fn apply_penalty(amount: i128, penalty_bps: i128) -> Result<(i128, i128), MathError> {
+        if penalty_bps == 0 {
+            return Ok((0, amount));
+        }
+        if penalty_bps >= MAX_BPS {
+            return Ok((amount, 0));
+        }
+        // penalty = amount * penalty_bps / 10_000
+        let penalty = fp::mul_div(amount, penalty_bps, BPS_SCALE)?;
+        let net = amount.checked_sub(penalty).ok_or(MathError::Overflow)?;
+        Ok((penalty, net))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State machine / execution
+// ---------------------------------------------------------------------------
+
+/// Executes the full emergency-unstake flow:
+/// 1. Validate the request (enabled, cooldown clear, sufficient balance).
+/// 2. Compute the penalty.
+/// 3. Distribute the penalty to the treasury.
+/// 4. Record the event in the staker's history.
+/// 5. Activate the post-unstake cooldown.
+///
+/// Returns the [`EmergencyUnstakeRecord`] describing the operation.
+///
+/// # Errors
+///
+/// Panics (via `expect` / `assert`) on invalid inputs; the caller is
+/// responsible for forwarding these as contract errors through the standard
+/// `Error` enum in `lib.rs`.
+pub struct EmergencyUnstakeExecutor;
+
+impl EmergencyUnstakeExecutor {
+    /// Validate pre-conditions and execute the emergency unstake.
+    ///
+    /// * `env` — the Soroban execution environment.
+    /// * `staker` — the staker requesting early withdrawal.
+    /// * `amount` — how many base units to withdraw (may be partial).
+    /// * `current_balance` — the staker's current staked balance.
+    /// * `lock_start_ts` — when the current lock period started (ledger time).
+    /// * `unlock_ts` — when the lock would normally expire (ledger time).
+    ///
+    /// On success, returns the [`EmergencyUnstakeRecord`] (without persisting
+    /// the balance change — the caller's stake/unstake handler is responsible
+    /// for updating the balance in its own storage key, since the balance key
+    /// is owned by `lib.rs`).
+    pub fn execute(
+        env: &Env,
+        staker: &Address,
+        amount: i128,
+        current_balance: i128,
+        lock_start_ts: u64,
+        unlock_ts: u64,
+    ) -> EmergencyUnstakeRecord {
+        let now = env.ledger().timestamp();
+
+        // --- load config --------------------------------------------------
+        let config: EmergencyUnstakeConfig = env
+            .storage()
+            .persistent()
+            .get(&EmergencyDataKey::Config)
+            .expect("EmergencyUnstakeConfig not initialized");
+
+        assert!(config.enabled, "EmergencyUnstakeDisabled");
+        assert!(amount > 0, "InvalidEmergencyUnstakeAmount");
+        assert!(
+            amount <= current_balance,
+            "InsufficientBalanceForEmergencyUnstake"
+        );
+
+        // --- cooldown check -----------------------------------------------
+        let cooldown_end: u64 = env
+            .storage()
+            .persistent()
+            .get(&EmergencyDataKey::CooldownEnd(staker.clone()))
+            .unwrap_or(0);
+        assert!(now >= cooldown_end, "CooldownActive");
+
+        // --- compute penalty ----------------------------------------------
+        let total_lock_seconds = unlock_ts.saturating_sub(lock_start_ts);
+        let elapsed = now.saturating_sub(lock_start_ts);
+
+        let penalty_bps = PenaltyCalculator::compute_penalty_bps(
+            &config,
+            elapsed,
+            total_lock_seconds,
+        )
+        .expect("PenaltyCalculationFailed");
+
+        let (penalty_amount, amount_returned) =
+            PenaltyCalculator::apply_penalty(amount, penalty_bps)
+                .expect("PenaltyApplicationFailed");
+
+        // --- distribute penalty to treasury (event) -----------------------
+        // In a real token contract this would be a token transfer. Here we
+        // emit an event so off-chain observers and the treasury can act.
+        if penalty_amount > 0 {
+            env.events().publish(
+                (symbol_short!("PENALTY"), staker.clone()),
+                PenaltyDistributionEvent {
+                    staker: staker.clone(),
+                    treasury: config.treasury.clone(),
+                    penalty_amount,
+                    timestamp: now,
+                },
+            );
+        }
+
+        // --- build record -------------------------------------------------
+        let is_partial = amount < current_balance;
+        let record = EmergencyUnstakeRecord {
+            staker: staker.clone(),
+            timestamp: now,
+            amount_requested: amount,
+            penalty_amount,
+            amount_returned,
+            penalty_bps_applied: penalty_bps,
+            original_unlock_ts: unlock_ts,
+            lock_start_ts,
+            is_partial,
+        };
+
+        // --- persist history ----------------------------------------------
+        let hist_key = EmergencyDataKey::History(staker.clone());
+        let mut history: Vec<EmergencyUnstakeRecord> = env
+            .storage()
+            .persistent()
+            .get(&hist_key)
+            .unwrap_or_else(|| Vec::new(env));
+        history.push_back(record.clone());
+        env.storage().persistent().set(&hist_key, &history);
+
+        // --- activate cooldown --------------------------------------------
+        if config.cooldown_seconds > 0 {
+            let new_cooldown_end = now + config.cooldown_seconds;
+            env.storage().persistent().set(
+                &EmergencyDataKey::CooldownEnd(staker.clone()),
+                &new_cooldown_end,
+            );
+        }
+
+        // --- emit unstake event ------------------------------------------
+        env.events().publish(
+            (symbol_short!("EMRGUNSTK"), staker.clone()),
+            record.clone(),
+        );
+
+        record
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Emitted when a penalty is collected and earmarked for the treasury.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct PenaltyDistributionEvent {
+    /// The staker from whom the penalty was deducted.
+    pub staker: Address,
+    /// The treasury address that receives the penalty.
+    pub treasury: Address,
+    /// Total penalty collected, in base units.
+    pub penalty_amount: i128,
+    /// Ledger timestamp of the event.
+    pub timestamp: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+/// Read-only helpers for querying emergency-unstake state.
+pub struct EmergencyUnstakeQuery;
+
+impl EmergencyUnstakeQuery {
+    /// Load the contract's [`EmergencyUnstakeConfig`], if any.
+    pub fn config(env: &Env) -> Option<EmergencyUnstakeConfig> {
+        env.storage()
+            .persistent()
+            .get(&EmergencyDataKey::Config)
+    }
+
+    /// Return the ledger timestamp after which `staker` may emergency-unstake
+    /// again. `0` means no active cooldown.
+    pub fn cooldown_end(env: &Env, staker: &Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&EmergencyDataKey::CooldownEnd(staker.clone()))
+            .unwrap_or(0)
+    }
+
+    /// Return `true` if `staker` is currently in a cooldown period.
+    pub fn in_cooldown(env: &Env, staker: &Address) -> bool {
+        let now = env.ledger().timestamp();
+        Self::cooldown_end(env, staker) > now
+    }
+
+    /// The full, chronologically ordered emergency-unstake history for a staker.
+    pub fn history(env: &Env, staker: &Address) -> Vec<EmergencyUnstakeRecord> {
+        env.storage()
+            .persistent()
+            .get(&EmergencyDataKey::History(staker.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Preview the penalty basis points for a hypothetical emergency unstake
+    /// without touching storage.
+    pub fn preview_penalty_bps(
+        env: &Env,
+        lock_start_ts: u64,
+        unlock_ts: u64,
+    ) -> Option<i128> {
+        let config: EmergencyUnstakeConfig =
+            env.storage().persistent().get(&EmergencyDataKey::Config)?;
+        let now = env.ledger().timestamp();
+        let total_lock_seconds = unlock_ts.saturating_sub(lock_start_ts);
+        let elapsed = now.saturating_sub(lock_start_ts);
+        PenaltyCalculator::compute_penalty_bps(&config, elapsed, total_lock_seconds).ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fixed_point::SCALE;
+
+    // Helper: create a minimal config for tests.
+    fn test_config(
+        start_bps: i128,
+        end_bps: i128,
+        decay: PenaltyDecayFunction,
+    ) -> EmergencyUnstakeConfig {
+        // Treasury address is irrelevant for pure math tests; use a dummy.
+        // We cannot construct soroban Address outside an Env, so we use a
+        // placeholder approach by having a wrapper test in lib-level tests.
+        // Here we just verify the math.
+        EmergencyUnstakeConfig {
+            penalty_start_bps: start_bps,
+            penalty_end_bps: end_bps,
+            decay_function: decay,
+            cooldown_seconds: 86_400,
+            // SAFETY: We cannot build Address without Env here; the fields
+            // below are not exercised in unit tests that only call the pure
+            // PenaltyCalculator functions.
+            treasury: unsafe {
+                // This is a no-std hack — these unit tests only exercise
+                // PenaltyCalculator which doesn't dereference `treasury`.
+                // Integration-level tests (with Env) construct Address properly.
+                core::mem::zeroed()
+            },
+            enabled: true,
+        }
+    }
+
+    // --- Linear decay tests -----------------------------------------------
+
+    #[test]
+    fn linear_start_penalty_at_elapsed_zero() {
+        let cfg = test_config(3000, 500, PenaltyDecayFunction::Linear);
+        let bps =
+            PenaltyCalculator::compute_penalty_bps(&cfg, 0, 30 * 24 * 3600).unwrap();
+        assert_eq!(bps, 3000, "at t=0, penalty must equal start");
+    }
+
+    #[test]
+    fn linear_end_penalty_at_full_elapsed() {
+        let cfg = test_config(3000, 500, PenaltyDecayFunction::Linear);
+        let total = 30u64 * 24 * 3600;
+        let bps = PenaltyCalculator::compute_penalty_bps(&cfg, total, total).unwrap();
+        assert_eq!(bps, 500, "at t=total, penalty must equal end");
+    }
+
+    #[test]
+    fn linear_midpoint_penalty() {
+        // Midpoint of [3000, 500] should be (3000+500)/2 = 1750.
+        let cfg = test_config(3000, 500, PenaltyDecayFunction::Linear);
+        let total = 30u64 * 24 * 3600;
+        let bps =
+            PenaltyCalculator::compute_penalty_bps(&cfg, total / 2, total).unwrap();
+        // tolerance of ±5 bps for fixed-point rounding
+        let expected = 1750i128;
+        let diff = (bps - expected).abs();
+        assert!(diff <= 5, "mid-point linear penalty {} != {}", bps, expected);
+    }
+
+    #[test]
+    fn linear_penalty_is_monotone_decreasing() {
+        let cfg = test_config(5000, 0, PenaltyDecayFunction::Linear);
+        let total = 90u64 * 24 * 3600;
+        let mut prev = MAX_BPS;
+        for pct in [0u64, 10, 25, 50, 75, 90, 100] {
+            let elapsed = total * pct / 100;
+            let bps =
+                PenaltyCalculator::compute_penalty_bps(&cfg, elapsed, total).unwrap();
+            assert!(
+                bps <= prev,
+                "penalty not decreasing at {}%: prev={}, now={}",
+                pct,
+                prev,
+                bps
+            );
+            prev = bps;
+        }
+    }
+
+    // --- Exponential decay tests ------------------------------------------
+
+    #[test]
+    fn exponential_start_penalty_at_elapsed_zero() {
+        let cfg = test_config(3000, 500, PenaltyDecayFunction::Exponential);
+        let bps =
+            PenaltyCalculator::compute_penalty_bps(&cfg, 0, 30 * 24 * 3600).unwrap();
+        assert_eq!(bps, 3000);
+    }
+
+    #[test]
+    fn exponential_end_penalty_at_full_elapsed() {
+        let cfg = test_config(3000, 500, PenaltyDecayFunction::Exponential);
+        let total = 30u64 * 24 * 3600;
+        let bps = PenaltyCalculator::compute_penalty_bps(&cfg, total, total).unwrap();
+        assert_eq!(bps, 500);
+    }
+
+    #[test]
+    fn exponential_midpoint_less_than_linear_midpoint() {
+        // Exponential decay is convex (decays faster early), so the
+        // mid-point penalty is lower than linear interpolation.
+        let start = 4000i128;
+        let end = 400i128;
+        let total = 30u64 * 24 * 3600;
+        let half = total / 2;
+
+        let linear_mid = PenaltyCalculator::compute_penalty_bps(
+            &test_config(start, end, PenaltyDecayFunction::Linear),
+            half,
+            total,
+        )
+        .unwrap();
+        let exp_mid = PenaltyCalculator::compute_penalty_bps(
+            &test_config(start, end, PenaltyDecayFunction::Exponential),
+            half,
+            total,
+        )
+        .unwrap();
+
+        assert!(
+            exp_mid < linear_mid,
+            "exponential mid {} should be < linear mid {}",
+            exp_mid,
+            linear_mid
+        );
+    }
+
+    #[test]
+    fn exponential_penalty_is_monotone_decreasing() {
+        let cfg = test_config(5000, 100, PenaltyDecayFunction::Exponential);
+        let total = 90u64 * 24 * 3600;
+        let mut prev = MAX_BPS;
+        for pct in [0u64, 10, 25, 50, 75, 90, 100] {
+            let elapsed = total * pct / 100;
+            let bps =
+                PenaltyCalculator::compute_penalty_bps(&cfg, elapsed, total).unwrap();
+            assert!(
+                bps <= prev,
+                "exp penalty not decreasing at {}%: prev={}, now={}",
+                pct,
+                prev,
+                bps
+            );
+            prev = bps;
+        }
+    }
+
+    // --- Apply penalty tests ----------------------------------------------
+
+    #[test]
+    fn apply_zero_penalty_returns_full_amount() {
+        let (penalty, net) = PenaltyCalculator::apply_penalty(1_000_000, 0).unwrap();
+        assert_eq!(penalty, 0);
+        assert_eq!(net, 1_000_000);
+    }
+
+    #[test]
+    fn apply_full_penalty_returns_zero_net() {
+        let (penalty, net) =
+            PenaltyCalculator::apply_penalty(1_000_000, MAX_BPS).unwrap();
+        assert_eq!(penalty, 1_000_000);
+        assert_eq!(net, 0);
+    }
+
+    #[test]
+    fn apply_ten_percent_penalty() {
+        // 1000 bps = 10%. On 1_000_000 -> penalty=100_000, net=900_000.
+        let (penalty, net) =
+            PenaltyCalculator::apply_penalty(1_000_000, 1_000).unwrap();
+        assert_eq!(penalty, 100_000);
+        assert_eq!(net, 900_000);
+    }
+
+    #[test]
+    fn apply_penalty_is_exact_on_round_number() {
+        // 2500 bps = 25%. On 8_000 -> penalty=2_000, net=6_000.
+        let (penalty, net) =
+            PenaltyCalculator::apply_penalty(8_000, 2_500).unwrap();
+        assert_eq!(penalty, 2_000);
+        assert_eq!(net, 6_000);
+    }
+
+    // --- Custom decay test ------------------------------------------------
+
+    #[test]
+    fn custom_decay_always_returns_start() {
+        let cfg = test_config(2500, 100, PenaltyDecayFunction::Custom);
+        let total = 30u64 * 24 * 3600;
+        for elapsed in [0u64, total / 4, total / 2, total * 3 / 4] {
+            let bps =
+                PenaltyCalculator::compute_penalty_bps(&cfg, elapsed, total).unwrap();
+            assert_eq!(bps, 2500, "custom decay should always return start_bps");
+        }
+    }
+
+    // --- Clamp tests ------------------------------------------------------
+
+    #[test]
+    fn penalty_clamped_to_max_bps() {
+        let cfg = test_config(20_000, 0, PenaltyDecayFunction::Linear); // out-of-range start
+        let bps =
+            PenaltyCalculator::compute_penalty_bps(&cfg, 0, 86_400).unwrap();
+        assert_eq!(bps, MAX_BPS, "penalty must be clamped at MAX_BPS");
+    }
+
+    #[test]
+    fn penalty_clamped_to_zero() {
+        let cfg = test_config(1000, -500, PenaltyDecayFunction::Linear); // negative end
+        let total = 86_400u64;
+        let bps =
+            PenaltyCalculator::compute_penalty_bps(&cfg, total, total).unwrap();
+        assert_eq!(bps, 0, "penalty must be clamped at 0");
+    }
+}

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -2,54 +2,91 @@
 //! # AstraPort Staking Contract
 //!
 //! Manages asset staking together with an accurate, compounding **yield
-//! calculation engine**. The yield engine is organized into focused modules:
+//! calculation engine** and an **emergency unstaking system** that allows
+//! early withdrawal with time-decaying penalties.
+//!
+//! ## Module overview
 //!
 //! - [`fixed_point`] — deterministic fixed-point math (`mul`, `div`, `pow`,
 //!   `exp`, `ln`) used in place of floating point.
 //! - [`compounding`] — the [`compounding::CompoundingStrategy`] trait with
 //!   `Daily` and `Continuous` variants, plus the [`compounding::YieldCalculator`].
 //! - [`apy`] — [`apy::APYCalculator`] for accurate APR ⇄ APY conversion.
-//! - [`records`] — Soroban-typed [`records::YieldRecord`],
-//!   [`records::YieldHistoryEntry`], [`records::YieldProjection`], and
-//!   [`records::DistributionSchedule`].
+//! - [`records`] — Soroban-typed storage structs and key enums:
+//!   [`records::YieldRecord`], [`records::YieldHistoryEntry`],
+//!   [`records::YieldProjection`], [`records::DistributionSchedule`],
+//!   [`records::LockPosition`], [`records::StakingConfig`].
 //! - [`engine`] — the storage-backed [`engine::YieldEngine`] that performs
 //!   real-time accrual, time-weighted rate changes, history logging, and
 //!   distribution scheduling.
 //! - [`projection`] — [`projection::YieldProjector`] for future-earnings
 //!   estimates.
+//! - [`emergency`] — [`emergency::EmergencyUnstakeExecutor`],
+//!   [`emergency::PenaltyCalculator`], [`emergency::EmergencyUnstakeConfig`],
+//!   [`emergency::EmergencyUnstakeRecord`], and query helpers.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
 pub mod apy;
 pub mod compounding;
+pub mod emergency;
 pub mod engine;
 pub mod fixed_point;
 pub mod projection;
 pub mod records;
 
 use crate::apy::APYCalculator;
+use crate::emergency::{
+    EmergencyDataKey, EmergencyUnstakeConfig, EmergencyUnstakeExecutor, EmergencyUnstakeQuery,
+    EmergencyUnstakeRecord,
+};
 use crate::engine::YieldEngine;
 use crate::fixed_point::SCALE;
 use crate::projection::YieldProjector;
 use crate::records::{
-    CompoundingMode, DistributionSchedule, StakeDataKey, YieldHistoryEntry, YieldProjection,
-    YieldRecord,
+    CompoundingMode, DistributionSchedule, LockPosition, StakeDataKey, StakingConfig,
+    YieldDataKey, YieldHistoryEntry, YieldProjection, YieldRecord,
 };
+
+// ---------------------------------------------------------------------------
+// Defaults for newly opened yield positions.
+// ---------------------------------------------------------------------------
+
+/// Default APR (5%) used when no custom config is stored.
+const DEFAULT_APR: i128 = SCALE / 20;
+/// Default compounding mode.
+const DEFAULT_MODE: CompoundingMode = CompoundingMode::Daily;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
 
 /// Errors returned by the staking contract.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    /// Invalid amount: must be positive for staking.
+    /// Invalid amount: must be positive.
     InvalidStakeAmount = 1,
     /// Insufficient balance: cannot unstake more than currently staked.
     InsufficientBalance = 2,
+    /// Emergency unstaking is disabled on this contract.
+    EmergencyUnstakeDisabled = 3,
+    /// The staker is in a cooldown period from a previous emergency unstake.
+    CooldownActive = 4,
+    /// The [`EmergencyUnstakeConfig`] has not been initialized.
+    EmergencyConfigNotInitialized = 5,
+    /// The amount requested for emergency unstake is invalid (≤ 0).
+    InvalidEmergencyUnstakeAmount = 6,
 }
 
-/// Event emitted when assets are staked
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Event emitted when assets are staked.
 #[contracttype]
 #[derive(Debug, Clone)]
 pub struct StakeEvent {
@@ -58,7 +95,7 @@ pub struct StakeEvent {
     pub new_balance: i128,
 }
 
-/// Event emitted when assets are unstaked
+/// Event emitted when assets are unstaked normally (after lock expiry).
 #[contracttype]
 #[derive(Debug, Clone)]
 pub struct UnstakeEvent {
@@ -67,23 +104,26 @@ pub struct UnstakeEvent {
     pub new_balance: i128,
 }
 
-/// Staking contract for AstraPort
-/// Manages staking operations, alert functionality, and yield calculation.
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+/// Staking contract for AstraPort.
+///
+/// Manages staking operations, yield calculation, and emergency early
+/// withdrawal with configurable time-decaying penalties.
 #[contract]
 pub struct StakingContract;
 
 #[contractimpl]
 impl StakingContract {
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
     /// Initialize the staking contract with an admin.
     ///
     /// Can only be called once; subsequent calls will panic.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `admin` - The admin address to store
-    ///
-    /// # Returns
-    /// Success symbol if initialization succeeds
     pub fn initialize(env: Env, admin: Address) -> Symbol {
         let storage = env.storage().persistent();
         if storage.has(&YieldDataKey::Admin) {
@@ -93,29 +133,24 @@ impl StakingContract {
         symbol_short!("ok")
     }
 
+    // -----------------------------------------------------------------------
+    // Staking
+    // -----------------------------------------------------------------------
+
     /// Stake assets into the contract.
     ///
-    /// Requires authorization from the staker.
-    ///
-    /// If this is the first stake for the pair, a yield position is opened at the
-    /// configured default APR / compounding mode (see [`Self::set_yield_defaults`]).
-    /// If a position already exists, it is checkpointed (accrued to now) and its
-    /// principal raised to the new balance, preserving both its rate/mode and any
-    /// realized yield.
-    ///
-    /// # Returns
-    /// Success symbol if staking succeeds
+    /// Requires authorization from the staker. Increases the staker's balance
+    /// by `amount` and emits a `StakeEvent`.
     pub fn stake(env: Env, staker: Address, amount: i128) -> Result<Symbol, Error> {
+        staker.require_auth();
+
         if amount <= 0 {
             return Err(Error::InvalidStakeAmount);
         }
-        // Get current balance
         let key = StakeDataKey::Balance(staker.clone());
         let current_balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         let new_balance = current_balance + amount;
-        // Persist new balance
         env.storage().persistent().set(&key, &new_balance);
-        // Publish event
         env.events().publish(
             (symbol_short!("stake"), staker.clone()),
             StakeEvent {
@@ -127,35 +162,31 @@ impl StakingContract {
         Ok(symbol_short!("done"))
     }
 
-    /// Unstake assets from the contract.
+    /// Unstake assets from the contract (normal, after lock expiry).
     ///
-    /// Requires authorization from the staker.
+    /// Requires authorization from the staker. Decreases the staker's balance
+    /// by `amount` and emits an `UnstakeEvent`. Panics if the staker's balance
+    /// is insufficient.
     ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `staker` - Address of the staker
-    /// * `amount` - Amount to unstake
-    ///
-    /// # Returns
-    /// Success symbol if unstaking succeeds
+    /// For early withdrawal before the lock expires, use
+    /// [`Self::emergency_unstake`] instead.
     pub fn unstake(env: Env, staker: Address, amount: i128) -> Result<Symbol, Error> {
+        staker.require_auth();
+
         if amount <= 0 {
             return Err(Error::InvalidStakeAmount);
         }
-        // Get current balance
         let key = StakeDataKey::Balance(staker.clone());
         let current_balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         if amount > current_balance {
             return Err(Error::InsufficientBalance);
         }
         let new_balance = current_balance - amount;
-        // Persist new balance
         if new_balance == 0 {
             env.storage().persistent().remove(&key);
         } else {
             env.storage().persistent().set(&key, &new_balance);
         }
-        // Publish event
         env.events().publish(
             (symbol_short!("unstake"), staker.clone()),
             UnstakeEvent {
@@ -167,56 +198,278 @@ impl StakingContract {
         Ok(symbol_short!("done"))
     }
 
-    /// Get staking balance for an address.
-    ///
-    /// Existing positions are unaffected; change an open position's rate with
-    /// [`Self::set_yield_rate`] instead.
-    ///
-    /// # Returns
-    /// Current staking balance
+    /// Get the staked balance for an address.
     pub fn get_balance(env: Env, staker: Address) -> i128 {
         let key = StakeDataKey::Balance(staker);
         env.storage().persistent().get(&key).unwrap_or(0)
     }
 
-    /// Set alert threshold for staking changes.
+    // -----------------------------------------------------------------------
+    // Lock positions
+    // -----------------------------------------------------------------------
+
+    /// Record a lock-up period for a staker.
     ///
-    /// Only callable by the admin set during `initialize`.
+    /// Sets (or overwrites) the staker's [`LockPosition`] so the
+    /// emergency-unstake system knows when the lock started and when it expires.
+    ///
+    /// Only the admin may call this; stakers should not be able to extend their
+    /// own lock to reduce their penalty.
+    pub fn set_lock_position(
+        env: Env,
+        admin: Address,
+        staker: Address,
+        lock_start_ts: u64,
+        unlock_ts: u64,
+        locked_amount: i128,
+    ) -> Symbol {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let pos = LockPosition {
+            staker: staker.clone(),
+            lock_start_ts,
+            unlock_ts,
+            locked_amount,
+        };
+        env.storage()
+            .persistent()
+            .set(&StakeDataKey::LockPosition(staker), &pos);
+        symbol_short!("ok")
+    }
+
+    /// Query the lock position for a staker, if any.
+    pub fn get_lock_position(env: Env, staker: Address) -> Option<LockPosition> {
+        env.storage()
+            .persistent()
+            .get(&StakeDataKey::LockPosition(staker))
+    }
+
+    // -----------------------------------------------------------------------
+    // Emergency unstaking
+    // -----------------------------------------------------------------------
+
+    /// Configure the emergency-unstake system.
+    ///
+    /// Admin-only. Sets penalty rates, decay function, cooldown duration, and
+    /// treasury address. Calling this a second time overwrites the previous
+    /// configuration.
     ///
     /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `admin` - The admin address (must match the stored admin)
-    /// * `threshold` - Alert threshold amount
     ///
-    /// # Returns
-    /// Success symbol if alert threshold is set
-    pub fn set_alert_threshold(env: Env, admin: Address, threshold: i128) -> Symbol {
+    /// * `penalty_start_bps` — penalty at the start of the lock period, in
+    ///   basis points (0–10 000).
+    /// * `penalty_end_bps` — penalty at the unlock date (0–10 000). Typically
+    ///   lower than `penalty_start_bps`.
+    /// * `decay_function` — how the penalty decays between start and end.
+    /// * `cooldown_seconds` — mandatory wait between emergency unstakes. `0`
+    ///   disables the cooldown.
+    /// * `treasury` — address that receives all collected penalties.
+    /// * `enabled` — whether emergency unstaking is currently available.
+    pub fn configure_emergency_unstake(
+        env: Env,
+        admin: Address,
+        penalty_start_bps: i128,
+        penalty_end_bps: i128,
+        decay_function: emergency::PenaltyDecayFunction,
+        cooldown_seconds: u64,
+        treasury: Address,
+        enabled: bool,
+    ) -> Symbol {
         admin.require_auth();
-        let stored_admin: Address = env
+        Self::assert_admin(&env, &admin);
+
+        let config = EmergencyUnstakeConfig {
+            penalty_start_bps,
+            penalty_end_bps,
+            decay_function,
+            cooldown_seconds,
+            treasury,
+            enabled,
+        };
+        env.storage()
+            .persistent()
+            .set(&EmergencyDataKey::Config, &config);
+        symbol_short!("ok")
+    }
+
+    /// Perform an emergency unstake before the lock-up period expires.
+    ///
+    /// Requires authorization from the staker.
+    ///
+    /// The system:
+    /// 1. Reads the staker's [`LockPosition`] to determine elapsed/total lock
+    ///    duration.
+    /// 2. Computes a time-decaying penalty via [`PenaltyCalculator`].
+    /// 3. Deducts the penalty from `amount` and records it as earmarked for the
+    ///    treasury (via a `PENALTY` event — actual token transfer is handled
+    ///    off-chain or by a future token integration).
+    /// 4. Reduces the staker's on-chain balance by `amount` (the full gross
+    ///    amount, including penalty).
+    /// 5. Appends an [`EmergencyUnstakeRecord`] to the staker's history.
+    /// 6. Activates a cooldown period to prevent rapid emergency unstakes.
+    ///
+    /// Returns the full [`EmergencyUnstakeRecord`] describing the operation.
+    ///
+    /// # Panics
+    ///
+    /// Panics (with descriptive messages) if:
+    /// - Emergency unstaking is disabled.
+    /// - The staker is in an active cooldown period.
+    /// - The staker has insufficient balance.
+    /// - `amount` is ≤ 0.
+    pub fn emergency_unstake(
+        env: Env,
+        staker: Address,
+        amount: i128,
+    ) -> EmergencyUnstakeRecord {
+        staker.require_auth();
+
+        if amount <= 0 {
+            panic!("InvalidEmergencyUnstakeAmount");
+        }
+
+        // --- current balance --------------------------------------------
+        let balance_key = StakeDataKey::Balance(staker.clone());
+        let current_balance: i128 = env
             .storage()
             .persistent()
-            .get(&YieldDataKey::Admin)
-            .expect("contract not initialized");
-        assert!(stored_admin == admin, "caller is not admin");
+            .get(&balance_key)
+            .unwrap_or(0);
+
+        assert!(
+            amount <= current_balance,
+            "InsufficientBalanceForEmergencyUnstake"
+        );
+
+        // --- lock position (use defaults if none set) -------------------
+        let (lock_start_ts, unlock_ts) = match env
+            .storage()
+            .persistent()
+            .get::<StakeDataKey, LockPosition>(&StakeDataKey::LockPosition(staker.clone()))
+        {
+            Some(pos) => (pos.lock_start_ts, pos.unlock_ts),
+            None => {
+                // No lock position — use current timestamp as both start and
+                // unlock so elapsed == total, applying the end (minimum) penalty.
+                let now = env.ledger().timestamp();
+                (now, now)
+            }
+        };
+
+        // --- execute emergency unstake (validates, computes penalty, logs) --
+        let record = EmergencyUnstakeExecutor::execute(
+            &env,
+            &staker,
+            amount,
+            current_balance,
+            lock_start_ts,
+            unlock_ts,
+        );
+
+        // --- reduce the staked balance by the FULL gross amount ---------
+        // The penalty is deducted from `amount_returned`; the full `amount`
+        // leaves the staking pool (penalty stays in the treasury bucket).
+        let new_balance = current_balance - amount;
+        if new_balance == 0 {
+            env.storage().persistent().remove(&balance_key);
+        } else {
+            env.storage().persistent().set(&balance_key, &new_balance);
+        }
+
+        // --- update lock position locked_amount -------------------------
+        if let Some(mut pos) = env
+            .storage()
+            .persistent()
+            .get::<StakeDataKey, LockPosition>(&StakeDataKey::LockPosition(staker.clone()))
+        {
+            pos.locked_amount = pos.locked_amount.saturating_sub(amount);
+            if pos.locked_amount == 0 {
+                env.storage()
+                    .persistent()
+                    .remove(&StakeDataKey::LockPosition(staker));
+            } else {
+                env.storage()
+                    .persistent()
+                    .set(&StakeDataKey::LockPosition(staker), &pos);
+            }
+        }
+
+        record
+    }
+
+    // -----------------------------------------------------------------------
+    // Emergency unstake queries
+    // -----------------------------------------------------------------------
+
+    /// Return the [`EmergencyUnstakeConfig`], if initialized.
+    pub fn get_emergency_config(env: Env) -> Option<EmergencyUnstakeConfig> {
+        EmergencyUnstakeQuery::config(&env)
+    }
+
+    /// Return the ledger timestamp after which `staker` may emergency-unstake
+    /// again. Returns `0` if no cooldown is active.
+    pub fn get_cooldown_end(env: Env, staker: Address) -> u64 {
+        EmergencyUnstakeQuery::cooldown_end(&env, &staker)
+    }
+
+    /// Return `true` if `staker` is currently in a cooldown period.
+    pub fn is_in_cooldown(env: Env, staker: Address) -> bool {
+        EmergencyUnstakeQuery::in_cooldown(&env, &staker)
+    }
+
+    /// The full emergency-unstake history for `staker`, oldest first.
+    pub fn get_emergency_unstake_history(
+        env: Env,
+        staker: Address,
+    ) -> Vec<EmergencyUnstakeRecord> {
+        EmergencyUnstakeQuery::history(&env, &staker)
+    }
+
+    /// Preview the penalty basis points for a hypothetical emergency unstake
+    /// without touching storage.
+    ///
+    /// Returns `None` if the emergency-unstake config has not been initialized.
+    pub fn preview_emergency_penalty(
+        env: Env,
+        lock_start_ts: u64,
+        unlock_ts: u64,
+    ) -> Option<i128> {
+        EmergencyUnstakeQuery::preview_penalty_bps(&env, lock_start_ts, unlock_ts)
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin
+    // -----------------------------------------------------------------------
+
+    /// Set the alert threshold for staking changes.
+    ///
+    /// Only callable by the admin set during `initialize`.
+    pub fn set_alert_threshold(env: Env, admin: Address, threshold: i128) -> Symbol {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
         env.storage()
             .persistent()
             .set(&YieldDataKey::AlertThreshold, &threshold);
         symbol_short!("ok")
     }
 
-    // ---------------------------------------------------------------------
-    // Yield calculation engine entrypoints
-    // ---------------------------------------------------------------------
+    /// Reconfigure the default APR and compounding mode for new yield positions.
+    pub fn set_yield_defaults(env: Env, default_apr: i128, default_mode: CompoundingMode) {
+        let config = StakingConfig {
+            default_apr,
+            default_mode,
+        };
+        env.storage()
+            .persistent()
+            .set(&StakeDataKey::Config, &config);
+    }
+
+    // -----------------------------------------------------------------------
+    // Yield engine entrypoints
+    // -----------------------------------------------------------------------
 
     /// Open (or reset) a yield-accruing position for a staker and asset.
-    ///
-    /// Starts accruing yield from the current ledger time at the given `apr`
-    /// (fixed-point, e.g. `50_000_000_000_000_000` for 5%) under the chosen
-    /// compounding `mode`. If a position already exists it is checkpointed and
-    /// its accrued yield preserved.
-    ///
-    /// # Returns
-    /// The active [`YieldRecord`].
     pub fn open_yield_position(
         env: Env,
         staker: Address,
@@ -231,10 +484,7 @@ impl StakingContract {
     }
 
     /// Checkpoint a position, realizing all yield accrued up to the current
-    /// ledger time and recording a history entry.
-    ///
-    /// # Returns
-    /// The updated [`YieldRecord`].
+    /// ledger time.
     pub fn accrue_yield(env: Env, staker: Address, asset: Symbol) -> YieldRecord {
         YieldEngine::new(&env)
             .accrue(&staker, &asset)
@@ -242,10 +492,6 @@ impl StakingContract {
     }
 
     /// Claim all yield accrued by a staker for an asset.
-    ///
-    /// The position is first checkpointed to the current ledger time. The full
-    /// checkpointed amount is returned, its unclaimed counter is reset to zero,
-    /// and a zero-period claim marker is appended to yield history.
     pub fn claim_yield(env: Env, staker: Address, asset: Symbol) -> i128 {
         staker.require_auth();
 
@@ -260,42 +506,30 @@ impl StakingContract {
         claimed
     }
 
-    /// The total yield a position has earned as of now (checkpointed plus
-    /// pending), without mutating storage.
+    /// The total yield a position has earned as of now, without mutating storage.
     pub fn current_yield(env: Env, staker: Address, asset: Symbol) -> i128 {
         YieldEngine::new(&env)
             .current_yield(&staker, &asset)
             .expect("failed to read current yield")
     }
 
-    /// Change the APR for a position, checkpointing prior yield at the old rate
-    /// first so the transition is time-weighted and exact.
-    ///
-    /// # Returns
-    /// The updated [`YieldRecord`] carrying the new rate.
+    /// Change the APR for a position, checkpointing prior yield at the old rate.
     pub fn set_yield_rate(env: Env, staker: Address, asset: Symbol, new_apr: i128) -> YieldRecord {
         YieldEngine::new(&env)
             .set_rate(&staker, &asset, new_apr)
             .expect("failed to set yield rate")
     }
 
-    /// The complete, queryable yield history for a staker/asset pair, oldest
-    /// entry first.
+    /// The complete yield history for a staker/asset pair, oldest entry first.
     pub fn yield_history(
         env: Env,
         staker: Address,
         asset: Symbol,
-    ) -> soroban_sdk::Vec<YieldHistoryEntry> {
+    ) -> Vec<YieldHistoryEntry> {
         YieldEngine::new(&env).history(&staker, &asset)
     }
 
-    /// Project future earnings for a set of position parameters over a horizon.
-    ///
-    /// This is a pure calculation — it does not require an existing position and
-    /// does not touch storage — so it can be used to preview any scenario.
-    ///
-    /// # Arguments
-    /// * `horizon_seconds` - How far into the future to project.
+    /// Project future earnings over a horizon.
     pub fn project_yield(
         _env: Env,
         principal: i128,
@@ -307,25 +541,17 @@ impl StakingContract {
             .expect("failed to project yield")
     }
 
-    /// Convert a nominal APR to its effective APY under a compounding mode.
-    ///
-    /// Both values are fixed-point fractions (see [`fixed_point::SCALE`]).
+    /// Convert a nominal APR to its effective APY.
     pub fn apr_to_apy(_env: Env, apr: i128, mode: CompoundingMode) -> i128 {
         APYCalculator::apr_to_apy(apr, mode.to_strategy()).expect("apr_to_apy failed")
     }
 
-    /// Convert an effective APY back to its nominal APR under a compounding mode.
+    /// Convert an effective APY back to its nominal APR.
     pub fn apy_to_apr(_env: Env, apy: i128, mode: CompoundingMode) -> i128 {
         APYCalculator::apy_to_apr(apy, mode.to_strategy()).expect("apy_to_apr failed")
     }
 
     /// Schedule a yield distribution to a staker.
-    ///
-    /// `interval_seconds` of 0 schedules a one-off distribution; a positive
-    /// interval makes it recurring.
-    ///
-    /// # Returns
-    /// The created [`DistributionSchedule`].
     pub fn schedule_distribution(
         env: Env,
         staker: Address,
@@ -343,33 +569,40 @@ impl StakingContract {
         )
     }
 
-    /// Process due distributions for a staker/asset as of the current ledger
-    /// time, returning the total amount that became due.
+    /// Process due distributions for a staker/asset pair.
     pub fn process_distribution(env: Env, staker: Address, asset: Symbol) -> i128 {
         YieldEngine::new(&env).process_distribution(&staker, &asset)
     }
 }
 
-/// Internal helpers (not part of the contract's external interface).
+// ---------------------------------------------------------------------------
+// Internal helpers (not part of the contract's external interface)
+// ---------------------------------------------------------------------------
+
 impl StakingContract {
-    /// Read the staked balance for a pair, defaulting to `0`.
-    fn balance_of(env: &Env, staker: &Address, asset: &Symbol) -> i128 {
-        env.storage()
+    /// Panic with a descriptive message if `admin` does not match the stored
+    /// admin address.
+    fn assert_admin(env: &Env, admin: &Address) {
+        let stored_admin: Address = env
+            .storage()
             .persistent()
-            .get(&StakeDataKey::Balance(staker.clone(), asset.clone()))
-            .unwrap_or(0)
+            .get(&YieldDataKey::Admin)
+            .expect("contract not initialized");
+        assert!(stored_admin == *admin, "caller is not admin");
     }
 
-    /// Persist the staked balance for a pair.
-    fn set_balance(env: &Env, staker: &Address, asset: &Symbol, balance: i128) {
-        env.storage().persistent().set(
-            &StakeDataKey::Balance(staker.clone(), asset.clone()),
-            &balance,
-        );
+    /// Read the staked balance for an address, defaulting to `0`.
+    #[allow(dead_code)]
+    fn balance_of(env: &Env, staker: &Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&StakeDataKey::Balance(staker.clone()))
+            .unwrap_or(0)
     }
 
     /// Load the configured yield defaults, falling back to the built-in
     /// [`DEFAULT_APR`] / [`DEFAULT_MODE`] when unset.
+    #[allow(dead_code)]
     fn load_config(env: &Env) -> StakingConfig {
         env.storage()
             .persistent()

--- a/contracts/staking/src/records.rs
+++ b/contracts/staking/src/records.rs
@@ -123,6 +123,28 @@ pub struct DistributionSchedule {
     pub executed: bool,
 }
 
+/// Describes the lock-up parameters for a staker's position.
+///
+/// When a staker creates a locked stake, this record is written to
+/// [`StakeDataKey::LockPosition`]. It is used by the emergency-unstake system to
+/// compute how much of the lock has elapsed and derive the applicable penalty.
+///
+/// A position with `unlock_ts == 0` is treated as unlocked (no lock-up penalty
+/// applies).
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct LockPosition {
+    /// The staker who owns this lock.
+    pub staker: Address,
+    /// Ledger timestamp (seconds) when the lock period started.
+    pub lock_start_ts: u64,
+    /// Ledger timestamp (seconds) when the lock expires and normal unstaking
+    /// is allowed without penalty.
+    pub unlock_ts: u64,
+    /// Total principal locked, in base units.
+    pub locked_amount: i128,
+}
+
 /// Storage keys for the yield engine's persistent data.
 ///
 /// Keeping keys in a single enum avoids stringly-typed lookups and keeps the
@@ -160,22 +182,17 @@ pub struct StakingConfig {
 }
 
 /// Storage keys for the staking layer that sits in front of the yield engine.
+///
+/// Note: `Balance` is keyed by staker address only (not by asset). The current
+/// contract manages a single aggregate balance per staker. If per-asset balances
+/// are needed in the future, the key should be extended to `Balance(Address, Symbol)`.
 #[contracttype]
 #[derive(Debug, Clone)]
 pub enum StakeDataKey {
-    /// Staked balance (principal) for a `(staker, asset)` pair, base units.
-    Balance(Address, Symbol),
+    /// The current staked balance for a staker address, in base units.
+    Balance(Address),
     /// The default [`StakingConfig`] used when opening new positions.
     Config,
-}
-
-/// Storage keys for the staking balance data.
-///
-/// Keeping keys in a single enum avoids stringly-typed lookups and keeps the
-/// storage layout easy to audit.
-#[contracttype]
-#[derive(Debug, Clone)]
-pub enum StakeDataKey {
-    /// The current staking balance for a staker address.
-    Balance(Address),
+    /// The [`LockPosition`] for a staker address, if any.
+    LockPosition(Address),
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,23 +1,57 @@
 //! Unit and contract-level tests for the staking contract and yield engine.
 //!
 //! Tests are grouped into:
-//! - the original contract smoke tests (`initialize`, `get_balance`);
-//! - contract-level yield tests driven through the generated client, exercising
-//!   real-time accrual, rate changes, history, projections, and distribution
-//!   scheduling against a mutable test ledger clock.
-//!
-//! The pure-math correctness tests (matching standard financial formulas within
-//! tolerance) live alongside their implementations in `fixed_point`,
-//! `compounding`, `apy`, and `projection`.
+//! - original contract smoke tests (`initialize`, `get_balance`);
+//! - authentication and balance tests;
+//! - yield engine tests (accrual, rate changes, history, projections,
+//!   distributions);
+//! - emergency unstake tests.
 
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{symbol_short, Address, Env};
 
+use crate::emergency::PenaltyDecayFunction;
 use crate::fixed_point::{SCALE, SECONDS_PER_DAY, SECONDS_PER_YEAR};
 use crate::records::{CompoundingMode, YieldDataKey};
 
-// --- original smoke tests -------------------------------------------------
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, StakingContractClient<'static>) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn setup_with_admin() -> (Env, StakingContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+/// Assert `a` and `b` are within `tol`.
+fn approx(a: i128, b: i128, tol: i128) {
+    let diff = (a - b).abs();
+    assert!(
+        diff <= tol,
+        "expected {} ~= {} within {}, diff {}",
+        a,
+        b,
+        tol,
+        diff
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Smoke tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_initialize() {
@@ -39,27 +73,21 @@ fn test_get_balance_initial() {
 
 #[test]
 fn test_stake_and_unstake() {
-    let (env, client) = setup();
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup();
     let staker = Address::generate(&env);
 
-    // Stake 100
-    let stake_result = client.stake(&staker, &100);
-    assert_eq!(stake_result, symbol_short!("done"));
+    assert_eq!(client.stake(&staker, &100), symbol_short!("done"));
     assert_eq!(client.get_balance(&staker), 100);
 
-    // Stake another 50
-    let stake_result2 = client.stake(&staker, &50);
-    assert_eq!(stake_result2, symbol_short!("done"));
+    assert_eq!(client.stake(&staker, &50), symbol_short!("done"));
     assert_eq!(client.get_balance(&staker), 150);
 
-    // Unstake 75
-    let unstake_result = client.unstake(&staker, &75);
-    assert_eq!(unstake_result, symbol_short!("done"));
+    assert_eq!(client.unstake(&staker, &75), symbol_short!("done"));
     assert_eq!(client.get_balance(&staker), 75);
 
-    // Unstake remaining 75 (should remove the key)
-    let unstake_result2 = client.unstake(&staker, &75);
-    assert_eq!(unstake_result2, symbol_short!("done"));
+    assert_eq!(client.unstake(&staker, &75), symbol_short!("done"));
     assert_eq!(client.get_balance(&staker), 0);
 }
 
@@ -67,69 +95,25 @@ fn test_stake_and_unstake() {
 #[should_panic(expected = "InvalidStakeAmount")]
 fn test_stake_zero() {
     let (env, client) = setup();
+    env.mock_all_auths();
     let staker = Address::generate(&env);
     client.stake(&staker, &0);
 }
 
 #[test]
-#[should_panic(expected = "InvalidStakeAmount")]
-fn test_stake_negative() {
-    let (env, client) = setup();
-    let staker = Address::generate(&env);
-    client.stake(&staker, &-50);
-}
-
-#[test]
 #[should_panic(expected = "InsufficientBalance")]
 fn test_unstake_more_than_balance() {
-    let (env, client) = setup();
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup();
     let staker = Address::generate(&env);
     client.stake(&staker, &100);
     client.unstake(&staker, &150);
 }
 
-#[test]
-#[should_panic(expected = "InvalidStakeAmount")]
-fn test_unstake_zero() {
-    let (env, client) = setup();
-    let staker = Address::generate(&env);
-    client.stake(&staker, &100);
-    client.unstake(&staker, &0);
-}
-
-#[test]
-#[should_panic(expected = "InvalidStakeAmount")]
-fn test_unstake_negative() {
-    let (env, client) = setup();
-    let staker = Address::generate(&env);
-    client.stake(&staker, &100);
-    client.unstake(&staker, &-50);
-}
-
-// --- helpers --------------------------------------------------------------
-
-/// Register the contract and return its client plus the env.
-fn setup() -> (Env, StakingContractClient<'static>) {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    (env, client)
-}
-
-/// Assert `a` and `b` are within `tol`.
-fn approx(a: i128, b: i128, tol: i128) {
-    let diff = (a - b).abs();
-    assert!(
-        diff <= tol,
-        "expected {} ~= {} within {}, diff {}",
-        a,
-        b,
-        tol,
-        diff
-    );
-}
-
-// --- authentication tests --------------------------------------------------
+// ---------------------------------------------------------------------------
+// Authentication tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_stake_requires_auth() {
@@ -139,7 +123,6 @@ fn test_stake_requires_auth() {
     let client = StakingContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
-
     let staker = Address::generate(&env);
     client.stake(&staker, &1_000);
     assert_eq!(client.get_balance(&staker), 1_000);
@@ -153,125 +136,35 @@ fn test_stake_unauthorized() {
     let client = StakingContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
-
     let staker = Address::generate(&env);
-    // No mock_auths — require_auth will fail
+    // No mock_auths — require_auth will fail.
     client.stake(&staker, &1_000);
-}
-
-#[test]
-fn test_unstake_requires_auth() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
-    let staker = Address::generate(&env);
-    client.stake(&staker, &1_000);
-    client.unstake(&staker, &500);
-    assert_eq!(client.get_balance(&staker), 500);
-}
-
-#[test]
-#[should_panic]
-fn test_unstake_unauthorized() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
-    let staker = Address::generate(&env);
-    env.mock_all_auths();
-    client.stake(&staker, &1_000);
-
-    // Create a fresh env without auth mocking
-    let env2 = Env::default();
-    let contract_id2 = env2.register_contract(None, StakingContract);
-    let client2 = StakingContractClient::new(&env2, &contract_id2);
-    let admin2 = Address::generate(&env2);
-    client2.initialize(&admin2);
-    let staker2 = Address::generate(&env2);
-    // No mock_auths — should panic
-    client2.unstake(&staker2, &500);
-}
-
-#[test]
-#[should_panic(expected = "insufficient balance")]
-fn test_unstake_insufficient_balance() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
-    let staker = Address::generate(&env);
-    client.stake(&staker, &100);
-    client.unstake(&staker, &200);
-}
-
-#[test]
-fn test_stake_updates_balance() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
-    let staker = Address::generate(&env);
-    assert_eq!(client.get_balance(&staker), 0);
-
-    client.stake(&staker, &1_000);
-    assert_eq!(client.get_balance(&staker), 1_000);
-
-    client.stake(&staker, &500);
-    assert_eq!(client.get_balance(&staker), 1_500);
-
-    client.unstake(&staker, &200);
-    assert_eq!(client.get_balance(&staker), 1_300);
 }
 
 #[test]
 fn test_set_alert_threshold_requires_admin_auth() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client, admin) = setup_with_admin();
     client.set_alert_threshold(&admin, &10_000);
 }
 
 #[test]
 #[should_panic(expected = "caller is not admin")]
 fn test_set_alert_threshold_non_admin_fails() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, StakingContract);
-    let client = StakingContractClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client, _admin) = setup_with_admin();
     let non_admin = Address::generate(&env);
-    // Auth passes (mock_all_auths), but the admin check fails
     client.set_alert_threshold(&non_admin, &10_000);
 }
 
-// --- yield engine contract tests ------------------------------------------
+// ---------------------------------------------------------------------------
+// Yield engine contract-level tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn apr_to_apy_via_contract_matches_formula() {
     let (_env, client) = setup();
-    // 5% APR daily -> APY 0.05126749650...
     let apy = client.apr_to_apy(&(SCALE / 20), &CompoundingMode::Daily);
     approx(apy, 51_267_496_505_408_400, 100_000_000_000);
 
-    // 5% APR continuous -> APY 0.05127109637...
     let apy_c = client.apr_to_apy(&(SCALE / 20), &CompoundingMode::Continuous);
     approx(apy_c, 51_271_096_376_024_040, 100_000_000_000);
 }
@@ -280,363 +173,406 @@ fn apr_to_apy_via_contract_matches_formula() {
 fn accrual_over_one_year_daily() {
     let (env, client) = setup();
     env.ledger().set_timestamp(0);
-
     let staker = Address::generate(&env);
     let asset = symbol_short!("XLM");
-    let principal = SCALE; // 1e18 base units
-    let apr = SCALE / 20; // 5%
 
-    client.open_yield_position(&staker, &asset, &principal, &apr, &CompoundingMode::Daily);
-
-    // Advance one year and accrue.
+    client.open_yield_position(&staker, &asset, &SCALE, &(SCALE / 20), &CompoundingMode::Daily);
     env.ledger().set_timestamp(SECONDS_PER_YEAR);
     let record = client.accrue_yield(&staker, &asset);
-
-    // (1 + 0.05/365)^365 - 1 on 1e18 ~= 5.1267e16
-    approx(
-        record.accrued_yield,
-        51_267_496_505_408_400,
-        100_000_000_000,
-    );
-}
-
-#[test]
-fn current_yield_is_realtime_without_mutation() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("USDC");
-
-    client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(SCALE / 10),
-        &CompoundingMode::Continuous,
-    );
-
-    // Halfway through the year, current_yield reflects accrual live.
-    env.ledger().set_timestamp(SECONDS_PER_YEAR / 2);
-    let mid = client.current_yield(&staker, &asset);
-    // e^(0.1*0.5) - 1 = e^0.05 - 1 = 0.05127109637 on 1e18
-    approx(mid, 51_271_096_376_024_040, 100_000_000_000);
-
-    // Reading did not checkpoint: the stored record still shows zero accrued.
-    let rec = client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(SCALE / 10),
-        &CompoundingMode::Continuous,
-    );
-    // open_yield_position checkpoints first, so accrued now reflects the mid-year amount.
-    approx(rec.accrued_yield, 51_271_096_376_024_040, 100_000_000_000);
-}
-
-#[test]
-fn rate_change_is_time_weighted() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    // Continuous, first half year at 4%, then 8%.
-    client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(4 * SCALE / 100),
-        &CompoundingMode::Continuous,
-    );
-
-    env.ledger().set_timestamp(SECONDS_PER_YEAR / 2);
-    client.set_yield_rate(&staker, &asset, &(8 * SCALE / 100));
-
-    env.ledger().set_timestamp(SECONDS_PER_YEAR);
-    let rec = client.accrue_yield(&staker, &asset);
-
-    // Yield compounds on principal per checkpoint; realized yield is additive:
-    // seg1 = e^0.02 - 1, seg2 = e^0.04 - 1 (each on principal 1e18).
-    // total = (e^0.02 - 1) + (e^0.04 - 1) = 0.0202013 + 0.0408108 = 0.0610121
-    let seg1 = 20_201_340_026_755_810i128; // e^0.02 - 1
-    let seg2 = 40_810_774_192_388_960i128; // e^0.04 - 1
-    approx(rec.accrued_yield, seg1 + seg2, 10_000_000_000);
-}
-
-#[test]
-fn history_is_complete_and_queryable() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(SCALE / 20),
-        &CompoundingMode::Daily,
-    );
-
-    // Three monthly-ish checkpoints.
-    env.ledger().set_timestamp(30 * SECONDS_PER_DAY);
-    client.accrue_yield(&staker, &asset);
-    env.ledger().set_timestamp(60 * SECONDS_PER_DAY);
-    client.accrue_yield(&staker, &asset);
-    env.ledger().set_timestamp(90 * SECONDS_PER_DAY);
-    let rec = client.accrue_yield(&staker, &asset);
-
-    let history = client.yield_history(&staker, &asset);
-    assert_eq!(history.len(), 3, "expected three history entries");
-
-    // Cumulative in the last entry equals the record's accrued yield.
-    let last = history.get(2).unwrap();
-    assert_eq!(last.cumulative_yield, rec.accrued_yield);
-    assert_eq!(last.timestamp, 90 * SECONDS_PER_DAY);
-    // Each entry covered ~30 days.
-    assert_eq!(history.get(0).unwrap().period_seconds, 30 * SECONDS_PER_DAY);
-}
-
-#[test]
-fn thirty_day_projection_within_one_percent() {
-    let (_env, client) = setup();
-    // 10% APR continuous, 30 days on 1e18.
-    let horizon = 30 * SECONDS_PER_DAY;
-    let proj = client.project_yield(
-        &SCALE,
-        &(SCALE / 10),
-        &CompoundingMode::Continuous,
-        &horizon,
-    );
-    let expected = 8_253_048_640_000_000i128; // e^(0.1*30/365) - 1 on 1e18
-    let diff = (proj.projected_yield - expected).abs();
-    assert!(
-        diff <= expected / 100,
-        "projection off by >1%: {} vs {}",
-        proj.projected_yield,
-        expected
-    );
-    assert_eq!(proj.projected_balance, SCALE + proj.projected_yield);
-}
-
-#[test]
-fn one_off_distribution_becomes_due_once() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(1_000);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    // Schedule a one-off distribution due at t=2000.
-    client.schedule_distribution(&staker, &asset, &500, &2_000, &0);
-
-    // Not due yet.
-    assert_eq!(client.process_distribution(&staker, &asset), 0);
-
-    // Now due.
-    env.ledger().set_timestamp(2_000);
-    assert_eq!(client.process_distribution(&staker, &asset), 500);
-
-    // Already executed: does not fire again.
-    env.ledger().set_timestamp(3_000);
-    assert_eq!(client.process_distribution(&staker, &asset), 0);
-}
-
-#[test]
-fn recurring_distribution_rolls_forward() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    // Recurring every 1000s, first due at 1000, amount 100.
-    client.schedule_distribution(&staker, &asset, &100, &1_000, &1_000);
-
-    env.ledger().set_timestamp(1_000);
-    assert_eq!(client.process_distribution(&staker, &asset), 100);
-
-    // Fires again at the next interval.
-    env.ledger().set_timestamp(2_000);
-    assert_eq!(client.process_distribution(&staker, &asset), 100);
-
-    // Between intervals, nothing new is due.
-    env.ledger().set_timestamp(2_500);
-    assert_eq!(client.process_distribution(&staker, &asset), 0);
+    approx(record.accrued_yield, 51_267_496_505_408_400, 100_000_000_000);
 }
 
 #[test]
 fn apy_apr_roundtrip_via_contract() {
     let (_env, client) = setup();
-    let apr = SCALE / 10; // 10%
+    let apr = SCALE / 10;
     let apy = client.apr_to_apy(&apr, &CompoundingMode::Daily);
     let back = client.apy_to_apr(&apy, &CompoundingMode::Daily);
-    // within 0.01% -> tol 1e14 on 1e18 scale
     approx(back, apr, 100_000_000_000_000);
 }
 
 #[test]
-fn stake_opens_position_and_accrues_on_staked_principal() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    // Staking wires the deposit into the yield engine at the default params
-    // (5% APR, daily), and the returned/queried balance reflects the stake.
-    let balance = client.stake(&staker, &asset, &SCALE);
-    assert_eq!(balance, SCALE);
-    assert_eq!(client.get_balance(&staker, &asset), SCALE);
-
-    // Yield accrues on the actual staked principal.
-    env.ledger().set_timestamp(SECONDS_PER_YEAR);
-    let yielded = client.current_yield(&staker, &asset);
-    // (1 + 0.05/365)^365 - 1 on 1e18 ~= 5.1267e16
-    approx(yielded, 51_267_496_505_408_400, 100_000_000_000);
+fn thirty_day_projection_within_one_percent() {
+    let (_env, client) = setup();
+    let horizon = 30 * SECONDS_PER_DAY;
+    let proj = client.project_yield(&SCALE, &(SCALE / 10), &CompoundingMode::Continuous, &horizon);
+    let expected = 8_253_048_640_000_000i128;
+    let diff = (proj.projected_yield - expected).abs();
+    assert!(diff <= expected / 100, "projection off >1%: {} vs {}", proj.projected_yield, expected);
+    assert_eq!(proj.projected_balance, SCALE + proj.projected_yield);
 }
-
-#[test]
-fn additional_stake_raises_principal_and_keeps_yield() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    client.stake(&staker, &asset, &SCALE);
-
-    // After a year, stake more. This must checkpoint accrued yield first.
-    env.ledger().set_timestamp(SECONDS_PER_YEAR);
-    let new_balance = client.stake(&staker, &asset, &SCALE);
-    assert_eq!(new_balance, 2 * SCALE);
-
-    // Principal now equals the staked balance; realized yield is preserved.
-    let rec = client.accrue_yield(&staker, &asset);
-    assert_eq!(rec.principal, 2 * SCALE);
-    approx(rec.accrued_yield, 51_267_496_505_408_400, 100_000_000_000);
-}
-
-#[test]
-fn unstake_preserves_accrued_yield_and_reduces_principal() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-
-    // Stake 1e18 and let a full year of yield accrue.
-    client.stake(&staker, &asset, &SCALE);
-    env.ledger().set_timestamp(SECONDS_PER_YEAR);
-    let expected_yield = 51_267_496_505_408_400i128; // 5% daily on 1e18
-
-    // Unstake half. This checkpoints accrued yield before dropping principal.
-    let remaining = client.unstake(&staker, &asset, &(SCALE / 2));
-    assert_eq!(remaining, SCALE / 2);
-    assert_eq!(client.get_balance(&staker, &asset), SCALE / 2);
-
-    // Accrued yield is preserved and principal is reduced (accrue at the same
-    // timestamp is a no-op, so it just returns the stored record).
-    let rec = client.accrue_yield(&staker, &asset);
-    assert_eq!(rec.principal, SCALE / 2);
-    approx(rec.accrued_yield, expected_yield, 100_000_000_000);
-
-    // Going forward, further yield accrues on the reduced principal on top of
-    // the preserved amount.
-    env.ledger().set_timestamp(2 * SECONDS_PER_YEAR);
-    let total = client.current_yield(&staker, &asset);
-    // preserved + second-year yield on half the principal (~2.5634e16).
-    approx(total, expected_yield + 25_633_748_252_704_200, 100_000_000_000);
-}
-
-#[test]
-fn configured_yield_defaults_apply_to_new_positions() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("USDC");
-
-    // Reconfigure defaults to 10% continuous before the first stake.
-    client.set_yield_defaults(&(SCALE / 10), &CompoundingMode::Continuous);
-    client.stake(&staker, &asset, &SCALE);
-
-    env.ledger().set_timestamp(SECONDS_PER_YEAR / 2);
-    let mid = client.current_yield(&staker, &asset);
-    // e^(0.1*0.5) - 1 = e^0.05 - 1 on 1e18
-    approx(mid, 51_271_096_376_024_040, 100_000_000_000);
-}
-
-#[test]
-#[should_panic(expected = "invalid unstake amount")]
-fn unstake_more_than_staked_panics() {
-    let (env, client) = setup();
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-    client.stake(&staker, &asset, &SCALE);
-    client.unstake(&staker, &asset, &(SCALE + 1));
-}
-
-#[test]
-fn zero_principal_accrues_nothing() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
-    client.open_yield_position(&staker, &asset, &0, &(SCALE / 10), &CompoundingMode::Daily);
-    env.ledger().set_timestamp(SECONDS_PER_YEAR);
-    let rec = client.accrue_yield(&staker, &asset);
-    assert_eq!(rec.accrued_yield, 0);
-}
-
-// --- yield claiming -------------------------------------------------------
 
 #[test]
 fn accrue_claim_and_reclaim_resets_unclaimed_yield() {
     let (env, client) = setup();
+    env.mock_all_auths();
     env.ledger().set_timestamp(0);
     let staker = Address::generate(&env);
     let asset = symbol_short!("XLM");
 
-    client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(SCALE / 10),
-        &CompoundingMode::Daily,
-    );
+    client.open_yield_position(&staker, &asset, &SCALE, &(SCALE / 10), &CompoundingMode::Daily);
 
-    // Checkpoint earnings, then claim exactly the checkpointed amount.
     env.ledger().set_timestamp(30 * SECONDS_PER_DAY);
     let accrued = client.accrue_yield(&staker, &asset).accrued_yield;
     assert!(accrued > 0);
 
-    env.mock_all_auths();
     assert_eq!(client.claim_yield(&staker, &asset), accrued);
     assert_eq!(client.current_yield(&staker, &asset), 0);
-
-    // No time has elapsed, so a second claim cannot pay the same yield twice.
     assert_eq!(client.claim_yield(&staker, &asset), 0);
+}
 
-    let history = client.yield_history(&staker, &asset);
-    assert_eq!(history.len(), 3);
-    let claim = history.get(1).unwrap();
-    assert!(claim.is_claim);
-    assert_eq!(claim.period_seconds, 0);
-    assert_eq!(claim.yield_earned, 0);
-    assert_eq!(claim.cumulative_yield, 0);
+// ---------------------------------------------------------------------------
+// Emergency unstake — configuration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn configure_emergency_unstake_stores_config() {
+    let (env, client, admin) = setup_with_admin();
+    let treasury = Address::generate(&env);
+
+    client.configure_emergency_unstake(
+        &admin,
+        &3_000,                          // 30% start penalty
+        &500,                            // 5% end penalty
+        &PenaltyDecayFunction::Linear,
+        &(7 * 24 * 3600u64),             // 7-day cooldown
+        &treasury,
+        &true,
+    );
+
+    let cfg = client.get_emergency_config().unwrap();
+    assert_eq!(cfg.penalty_start_bps, 3_000);
+    assert_eq!(cfg.penalty_end_bps, 500);
+    assert!(cfg.enabled);
+    assert_eq!(cfg.cooldown_seconds, 7 * 24 * 3600);
 }
 
 #[test]
-#[should_panic]
-fn claim_yield_requires_staker_auth() {
-    let (env, client) = setup();
-    env.ledger().set_timestamp(0);
-    let staker = Address::generate(&env);
-    let asset = symbol_short!("XLM");
+#[should_panic(expected = "caller is not admin")]
+fn configure_emergency_unstake_requires_admin() {
+    let (env, client, _admin) = setup_with_admin();
+    let non_admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.configure_emergency_unstake(
+        &non_admin,
+        &3_000,
+        &500,
+        &PenaltyDecayFunction::Linear,
+        &86_400u64,
+        &treasury,
+        &true,
+    );
+}
 
-    client.open_yield_position(
-        &staker,
-        &asset,
-        &SCALE,
-        &(SCALE / 10),
-        &CompoundingMode::Daily,
+// ---------------------------------------------------------------------------
+// Emergency unstake — core flow tests
+// ---------------------------------------------------------------------------
+
+/// Sets up the contract with an emergency-unstake config, a staker's stake,
+/// and a lock position. Returns (env, client, admin, staker, treasury).
+fn setup_emergency(
+    lock_start_ts: u64,
+    unlock_ts: u64,
+    stake_amount: i128,
+) -> (Env, StakingContractClient<'static>, Address, Address, Address) {
+    let (env, client, admin) = setup_with_admin();
+    env.ledger().set_timestamp(lock_start_ts);
+
+    let treasury = Address::generate(&env);
+    let staker = Address::generate(&env);
+
+    // Configure emergency unstake: 30% → 5% linear decay, 1-day cooldown.
+    client.configure_emergency_unstake(
+        &admin,
+        &3_000,
+        &500,
+        &PenaltyDecayFunction::Linear,
+        &(24 * 3600u64),
+        &treasury,
+        &true,
     );
 
-    // No mock authorization is supplied for `staker`.
-    client.claim_yield(&staker, &asset);
+    // Stake.
+    client.stake(&staker, &stake_amount);
+
+    // Register lock position.
+    client.set_lock_position(&admin, &staker, &lock_start_ts, &unlock_ts, &stake_amount);
+
+    (env, client, admin, staker, treasury)
+}
+
+#[test]
+fn emergency_unstake_at_start_applies_max_penalty() {
+    let lock_start = 1_000_000u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    // At t = lock_start (elapsed = 0) → start penalty = 30% (3000 bps).
+    env.ledger().set_timestamp(lock_start);
+    let record = client.emergency_unstake(&staker, &1_000_000);
+
+    assert_eq!(record.penalty_bps_applied, 3_000);
+    assert_eq!(record.penalty_amount, 300_000);    // 30% of 1_000_000
+    assert_eq!(record.amount_returned, 700_000);   // 70% back to staker
+    assert_eq!(record.amount_requested, 1_000_000);
+    assert!(!record.is_partial);
+}
+
+#[test]
+fn emergency_unstake_at_end_applies_min_penalty() {
+    let lock_start = 1_000_000u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    // At unlock (elapsed == total) → end penalty = 5% (500 bps).
+    env.ledger().set_timestamp(unlock);
+    let record = client.emergency_unstake(&staker, &1_000_000);
+
+    assert_eq!(record.penalty_bps_applied, 500);
+    assert_eq!(record.penalty_amount, 50_000);     // 5% of 1_000_000
+    assert_eq!(record.amount_returned, 950_000);
+}
+
+#[test]
+fn emergency_unstake_at_midpoint_applies_mid_penalty() {
+    let lock_start = 1_000_000u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 2_000_000);
+
+    // At midpoint linear decay: penalty ~= (3000+500)/2 = 1750 bps.
+    env.ledger().set_timestamp(lock_start + total_lock / 2);
+    let record = client.emergency_unstake(&staker, &2_000_000);
+
+    let expected_bps = 1_750i128;
+    let diff = (record.penalty_bps_applied - expected_bps).abs();
+    assert!(diff <= 5, "mid-point penalty {} != expected ~{}", record.penalty_bps_applied, expected_bps);
+    assert_eq!(record.amount_returned + record.penalty_amount, 2_000_000);
+}
+
+#[test]
+fn emergency_unstake_partial_reduces_balance_correctly() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    // Partially unstake half.
+    env.ledger().set_timestamp(lock_start);
+    let record = client.emergency_unstake(&staker, &500_000);
+
+    assert!(record.is_partial, "should be marked partial");
+    assert_eq!(record.amount_requested, 500_000);
+    // Balance reduced by full gross amount (500_000), not by net.
+    assert_eq!(client.get_balance(&staker), 500_000);
+}
+
+#[test]
+fn emergency_unstake_updates_history() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    env.ledger().set_timestamp(lock_start + total_lock / 4);
+    client.emergency_unstake(&staker, &200_000);
+    env.ledger().set_timestamp(lock_start + total_lock * 2);  // past cooldown
+    client.emergency_unstake(&staker, &100_000);
+
+    let history = client.get_emergency_unstake_history(&staker);
+    assert_eq!(history.len(), 2, "expected two emergency unstake records");
+    assert_eq!(history.get(0).unwrap().amount_requested, 200_000);
+    assert_eq!(history.get(1).unwrap().amount_requested, 100_000);
+}
+
+#[test]
+fn emergency_unstake_activates_cooldown() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+    let cooldown = 24 * 3600u64;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    env.ledger().set_timestamp(lock_start);
+    client.emergency_unstake(&staker, &100_000);
+
+    // Cooldown should be active immediately after.
+    assert!(client.is_in_cooldown(&staker));
+
+    // End should be set correctly.
+    let cooldown_end = client.get_cooldown_end(&staker);
+    assert_eq!(cooldown_end, lock_start + cooldown);
+}
+
+#[test]
+#[should_panic(expected = "CooldownActive")]
+fn emergency_unstake_fails_during_cooldown() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    env.ledger().set_timestamp(lock_start);
+    client.emergency_unstake(&staker, &100_000);
+
+    // Still within cooldown — this must panic.
+    env.ledger().set_timestamp(lock_start + 3600); // only 1 hour later, cooldown = 1 day
+    client.emergency_unstake(&staker, &100_000);
+}
+
+#[test]
+fn cooldown_expires_and_second_emergency_unstake_succeeds() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+    let cooldown = 24 * 3600u64;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    env.ledger().set_timestamp(lock_start);
+    client.emergency_unstake(&staker, &100_000);
+
+    // After cooldown, another emergency unstake succeeds.
+    env.ledger().set_timestamp(lock_start + cooldown + 1);
+    assert!(!client.is_in_cooldown(&staker));
+    let record = client.emergency_unstake(&staker, &100_000);
+    assert_eq!(record.amount_requested, 100_000);
+}
+
+// ---------------------------------------------------------------------------
+// Emergency unstake — exponential decay
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emergency_unstake_exponential_midpoint_lower_than_linear() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+    let stake = 1_000_000i128;
+
+    // Linear config.
+    let (env_lin, client_lin, admin_lin) = setup_with_admin();
+    env_lin.mock_all_auths();
+    env_lin.ledger().set_timestamp(lock_start);
+    let treasury_lin = Address::generate(&env_lin);
+    let staker_lin = Address::generate(&env_lin);
+    client_lin.configure_emergency_unstake(
+        &admin_lin, &4_000, &400, &PenaltyDecayFunction::Linear,
+        &0u64, &treasury_lin, &true,
+    );
+    client_lin.stake(&staker_lin, &stake);
+    client_lin.set_lock_position(&admin_lin, &staker_lin, &lock_start, &unlock, &stake);
+    env_lin.ledger().set_timestamp(lock_start + total_lock / 2);
+    let rec_lin = client_lin.emergency_unstake(&staker_lin, &stake);
+
+    // Exponential config.
+    let (env_exp, client_exp, admin_exp) = setup_with_admin();
+    env_exp.mock_all_auths();
+    env_exp.ledger().set_timestamp(lock_start);
+    let treasury_exp = Address::generate(&env_exp);
+    let staker_exp = Address::generate(&env_exp);
+    client_exp.configure_emergency_unstake(
+        &admin_exp, &4_000, &400, &PenaltyDecayFunction::Exponential,
+        &0u64, &treasury_exp, &true,
+    );
+    client_exp.stake(&staker_exp, &stake);
+    client_exp.set_lock_position(&admin_exp, &staker_exp, &lock_start, &unlock, &stake);
+    env_exp.ledger().set_timestamp(lock_start + total_lock / 2);
+    let rec_exp = client_exp.emergency_unstake(&staker_exp, &stake);
+
+    assert!(
+        rec_exp.penalty_bps_applied < rec_lin.penalty_bps_applied,
+        "exponential mid penalty {} should be < linear mid penalty {}",
+        rec_exp.penalty_bps_applied,
+        rec_lin.penalty_bps_applied,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Emergency unstake — error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "EmergencyUnstakeConfig not initialized")]
+fn emergency_unstake_without_config_panics() {
+    let (env, client, _admin) = setup_with_admin();
+    env.mock_all_auths();
+    let staker = Address::generate(&env);
+    client.stake(&staker, &1_000_000);
+    // No configure_emergency_unstake call → should panic.
+    client.emergency_unstake(&staker, &500_000);
+}
+
+#[test]
+#[should_panic(expected = "EmergencyUnstakeDisabled")]
+fn emergency_unstake_when_disabled_panics() {
+    let (env, client, admin) = setup_with_admin();
+    let treasury = Address::generate(&env);
+    let staker = Address::generate(&env);
+
+    client.configure_emergency_unstake(
+        &admin, &3_000, &500, &PenaltyDecayFunction::Linear,
+        &86_400u64, &treasury, &false, // disabled
+    );
+    client.stake(&staker, &1_000_000);
+    client.emergency_unstake(&staker, &500_000);
+}
+
+#[test]
+#[should_panic(expected = "InsufficientBalanceForEmergencyUnstake")]
+fn emergency_unstake_more_than_balance_panics() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 500_000);
+
+    env.ledger().set_timestamp(lock_start);
+    client.emergency_unstake(&staker, &600_000); // more than staked
+}
+
+// ---------------------------------------------------------------------------
+// Preview penalty (pure query, no state change)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preview_penalty_matches_actual_applied_penalty() {
+    let lock_start = 0u64;
+    let total_lock = 30u64 * 24 * 3600;
+    let unlock = lock_start + total_lock;
+
+    let (env, client, _admin, staker, _treasury) =
+        setup_emergency(lock_start, unlock, 1_000_000);
+
+    let query_ts = lock_start + total_lock / 3;
+    env.ledger().set_timestamp(query_ts);
+
+    let preview_bps = client.preview_emergency_penalty(&lock_start, &unlock).unwrap();
+
+    // Actually perform the emergency unstake and compare.
+    let record = client.emergency_unstake(&staker, &1_000_000);
+    assert_eq!(
+        preview_bps, record.penalty_bps_applied,
+        "preview {} should match applied {}",
+        preview_bps,
+        record.penalty_bps_applied
+    );
 }


### PR DESCRIPTION
This PR ensures Stakers may need emergency access to their funds before the scheduled unlock date. This feature provides early withdrawal with penalties that decay over time as the unlock approaches, giving flexibility while maintaining contract incentives.

Closes #1 