### PR TITLE
`feat(audit): comprehensive audit logging and activity tracking system`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
 name = "astraport-emergency"
 version = "0.1.0"
 dependencies = [
+ "astraport-audit",
  "soroban-sdk",
 ]
 
@@ -112,6 +113,7 @@ dependencies = [
 name = "astraport-trade"
 version = "0.1.0"
 dependencies = [
+ "astraport-audit",
  "soroban-sdk",
 ]
 

--- a/contracts/audit/Cargo.toml
+++ b/contracts/audit/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/audit/src/export.rs
+++ b/contracts/audit/src/export.rs
@@ -29,7 +29,8 @@ fn symbol_to_rust(s: &soroban_sdk::Symbol) -> RustString {
 
 /// CSV header shared by all exports. Column order is part of the contract
 /// protocol and is pinned by tests.
-pub const CSV_HEADER: &str = "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail,hash";
+pub const CSV_HEADER: &str =
+    "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail,hash";
 
 /// Extended CSV header including state snapshots.
 pub const CSV_HEADER_FULL: &str = "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail,hash,state_before,state_after";

--- a/contracts/audit/src/export.rs
+++ b/contracts/audit/src/export.rs
@@ -29,7 +29,10 @@ fn symbol_to_rust(s: &soroban_sdk::Symbol) -> RustString {
 
 /// CSV header shared by all exports. Column order is part of the contract
 /// protocol and is pinned by tests.
-pub const CSV_HEADER: &str = "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail";
+pub const CSV_HEADER: &str = "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail,hash";
+
+/// Extended CSV header including state snapshots.
+pub const CSV_HEADER_FULL: &str = "seq,timestamp,event_type,actor,permissions,portfolio,outcome,detail,hash,state_before,state_after";
 
 #[allow(dead_code)]
 fn to_rust_str(s: &String) -> RustString {
@@ -52,7 +55,7 @@ fn symbol_to_rust_str(env: &Env, s: &Symbol) -> RustString {
 /// One JSON object per `AuditLog` (no surrounding array).
 pub fn format_json_entry(env: &Env, entry: &AuditLog) -> String {
     let rs: RustString = format!(
-        "{{\"seq\":{},\"timestamp\":{},\"event_type\":\"{}\",\"actor\":\"{:?}\",\"permissions\":{},\"portfolio\":\"{:?}\",\"outcome\":\"{:?}\",\"detail\":\"{}\"}}",
+        "{{\"seq\":{},\"timestamp\":{},\"event_type\":\"{}\",\"actor\":\"{:?}\",\"permissions\":{},\"portfolio\":\"{:?}\",\"outcome\":\"{:?}\",\"detail\":\"{}\",\"hash\":\"{}\"}}",
         entry.seq,
         entry.timestamp,
         event_type_name(entry.event_type),
@@ -61,6 +64,26 @@ pub fn format_json_entry(env: &Env, entry: &AuditLog) -> String {
         symbol_to_rust(&entry.portfolio),
         symbol_to_rust(&entry.outcome),
         json_escape(&soroban_str(&entry.detail)),
+        hex_encode_hash(env, &entry.hash),
+    );
+    String::from_str(env, &rs)
+}
+
+/// Extended JSON object including state snapshots.
+pub fn format_json_entry_full(env: &Env, entry: &AuditLog) -> String {
+    let rs: RustString = format!(
+        "{{\"seq\":{},\"timestamp\":{},\"event_type\":\"{}\",\"actor\":\"{:?}\",\"permissions\":{},\"portfolio\":\"{:?}\",\"outcome\":\"{:?}\",\"detail\":\"{}\",\"hash\":\"{}\",\"state_before\":{},\"state_after\":{}}}",
+        entry.seq,
+        entry.timestamp,
+        event_type_name(entry.event_type),
+        soroban_str(&entry.actor.to_string()),
+        entry.permissions,
+        symbol_to_rust(&entry.portfolio),
+        symbol_to_rust(&entry.outcome),
+        json_escape(&soroban_str(&entry.detail)),
+        hex_encode_hash(env, &entry.hash),
+        snapshot_to_json(env, &entry.state_before),
+        snapshot_to_json(env, &entry.state_after),
     );
     String::from_str(env, &rs)
 }
@@ -68,7 +91,7 @@ pub fn format_json_entry(env: &Env, entry: &AuditLog) -> String {
 /// One CSV row matching [`CSV_HEADER`].
 pub fn format_csv_row(env: &Env, entry: &AuditLog) -> String {
     let rs: RustString = format!(
-        "{},{},{},{:?},{},{:?},{:?},{}",
+        "{},{},{},{:?},{},{:?},{:?},{},{}",
         entry.seq,
         entry.timestamp,
         event_type_name(entry.event_type),
@@ -77,6 +100,26 @@ pub fn format_csv_row(env: &Env, entry: &AuditLog) -> String {
         symbol_to_rust(&entry.portfolio),
         symbol_to_rust(&entry.outcome),
         csv_escape(&soroban_str(&entry.detail)),
+        hex_encode_hash(env, &entry.hash),
+    );
+    String::from_str(env, &rs)
+}
+
+/// Extended CSV row including state snapshots.
+pub fn format_csv_row_full(env: &Env, entry: &AuditLog) -> String {
+    let rs: RustString = format!(
+        "{},{},{},{:?},{},{:?},{:?},{},{},{},{}",
+        entry.seq,
+        entry.timestamp,
+        event_type_name(entry.event_type),
+        soroban_str(&entry.actor.to_string()),
+        entry.permissions,
+        symbol_to_rust(&entry.portfolio),
+        symbol_to_rust(&entry.outcome),
+        csv_escape(&soroban_str(&entry.detail)),
+        hex_encode_hash(env, &entry.hash),
+        csv_escape(&snapshot_to_compact(env, &entry.state_before)),
+        csv_escape(&snapshot_to_compact(env, &entry.state_after)),
     );
     String::from_str(env, &rs)
 }
@@ -92,6 +135,15 @@ pub fn format_jsonl(env: &Env, entries: &Vec<AuditLog>) -> Vec<String> {
     out
 }
 
+/// Extended JSON-Lines exporter including state snapshots.
+pub fn format_jsonl_full(env: &Env, entries: &Vec<AuditLog>) -> Vec<String> {
+    let mut out = Vec::new(env);
+    for entry in entries.iter() {
+        out.push_back(format_json_entry_full(env, &entry));
+    }
+    out
+}
+
 /// CSV batch exporter: first row is the header, subsequent rows are entries.
 pub fn format_csv(env: &Env, entries: &Vec<AuditLog>) -> Vec<String> {
     let mut out = Vec::new(env);
@@ -102,7 +154,65 @@ pub fn format_csv(env: &Env, entries: &Vec<AuditLog>) -> Vec<String> {
     out
 }
 
+/// Extended CSV exporter including state snapshots.
+pub fn format_csv_full(env: &Env, entries: &Vec<AuditLog>) -> Vec<String> {
+    let mut out = Vec::new(env);
+    out.push_back(String::from_str(env, CSV_HEADER_FULL));
+    for entry in entries.iter() {
+        out.push_back(format_csv_row_full(env, &entry));
+    }
+    out
+}
+
 // ---- internals ----
+
+/// Hex-encode a 32-byte hash for human-readable output.
+fn hex_encode_hash(_env: &Env, hash: &soroban_sdk::BytesN<32>) -> RustString {
+    let bytes = hash.to_array();
+    let mut out = RustString::with_capacity(64);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for &b in bytes.iter() {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Convert a StateSnapshot to a compact string representation.
+fn snapshot_to_compact(_env: &Env, snapshot: &crate::records::StateSnapshot) -> RustString {
+    let mut out = RustString::from("{");
+    let mut first = true;
+    for entry in snapshot.fields.iter() {
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push_str(&symbol_to_rust(&entry.key));
+        out.push(':');
+        out.push_str(&RustString::from(entry.value.to_string()));
+    }
+    out.push('}');
+    out
+}
+
+/// Convert a StateSnapshot to a JSON array string.
+fn snapshot_to_json(_env: &Env, snapshot: &crate::records::StateSnapshot) -> RustString {
+    let mut out = RustString::from("[");
+    let mut first = true;
+    for entry in snapshot.fields.iter() {
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push_str("{\"key\":\"");
+        out.push_str(&symbol_to_rust(&entry.key));
+        out.push_str("\",\"value\":");
+        out.push_str(&RustString::from(entry.value.to_string()));
+        out.push('}');
+    }
+    out.push(']');
+    out
+}
 
 fn event_type_name(t: AuditEventType) -> &'static str {
     match t {
@@ -115,6 +225,17 @@ fn event_type_name(t: AuditEventType) -> &'static str {
         AuditEventType::Withdrawal => "Withdrawal",
         AuditEventType::ScheduleChange => "ScheduleChange",
         AuditEventType::AdminAction => "AdminAction",
+        AuditEventType::PortfolioCreated => "PortfolioCreated",
+        AuditEventType::RoleChange => "RoleChange",
+        AuditEventType::YieldClaim => "YieldClaim",
+        AuditEventType::GovernanceProposal => "GovernanceProposal",
+        AuditEventType::GovernanceVote => "GovernanceVote",
+        AuditEventType::TreasuryAction => "TreasuryAction",
+        AuditEventType::EmergencyPause => "EmergencyPause",
+        AuditEventType::TradeExecution => "TradeExecution",
+        AuditEventType::OrderPlaced => "OrderPlaced",
+        AuditEventType::OrderCancelled => "OrderCancelled",
+        AuditEventType::FeeCollection => "FeeCollection",
         AuditEventType::Custom => "Custom",
     }
 }

--- a/contracts/audit/src/lib.rs
+++ b/contracts/audit/src/lib.rs
@@ -36,6 +36,7 @@ pub mod export;
 pub mod log_query;
 pub mod logger;
 pub mod records;
+pub mod signing;
 
 use crate::checksum::{chain_hash, entry_payload, first_chain_hash};
 use crate::records::{
@@ -229,6 +230,11 @@ impl AuditContract {
         Self::append_index(
             &env,
             &StorageKey::IndexByPortfolio(entry.portfolio.clone(), Self::bucket(seq)),
+            seq,
+        );
+        Self::append_index(
+            &env,
+            &StorageKey::IndexByOutcome(entry.outcome.clone(), Self::bucket(seq)),
             seq,
         );
 
@@ -476,6 +482,43 @@ impl AuditContract {
     pub fn export_csv(env: Env, q: log_query::LogQuery) -> Vec<String> {
         let entries = Self::query(env.clone(), q);
         export::format_csv(&env, &entries)
+    }
+
+    /// Export the result of a [`LogQuery`] as JSON-Lines including state
+    /// snapshots and chain hashes.
+    pub fn export_jsonl_full(env: Env, q: log_query::LogQuery) -> Vec<String> {
+        let entries = Self::query(env.clone(), q);
+        export::format_jsonl_full(&env, &entries)
+    }
+
+    /// Export the result of a [`LogQuery`] as CSV including state snapshots
+    /// and chain hashes (header row first).
+    pub fn export_csv_full(env: Env, q: log_query::LogQuery) -> Vec<String> {
+        let entries = Self::query(env.clone(), q);
+        export::format_csv_full(&env, &entries)
+    }
+
+    /// Compute the SHA-256 digest of audit entries for off-chain signing.
+    ///
+    /// Returns the digest that should be signed with ed25519 off-chain.
+    pub fn compute_export_digest(
+        env: Env,
+        q: log_query::LogQuery,
+    ) -> soroban_sdk::BytesN<32> {
+        let entries = Self::query(env.clone(), q);
+        signing::compute_digest(&env, &entries)
+    }
+
+    /// Verify a signed audit export against a known public key.
+    ///
+    /// Panics (aborting the transaction) if the signature is invalid.
+    /// This is the secure default for Soroban contracts.
+    pub fn verify_export(
+        env: Env,
+        export: signing::SignedExport,
+        public_key: soroban_sdk::BytesN<32>,
+    ) {
+        signing::verify_export(&env, &export, &public_key)
     }
 }
 

--- a/contracts/audit/src/lib.rs
+++ b/contracts/audit/src/lib.rs
@@ -501,10 +501,7 @@ impl AuditContract {
     /// Compute the SHA-256 digest of audit entries for off-chain signing.
     ///
     /// Returns the digest that should be signed with ed25519 off-chain.
-    pub fn compute_export_digest(
-        env: Env,
-        q: log_query::LogQuery,
-    ) -> soroban_sdk::BytesN<32> {
+    pub fn compute_export_digest(env: Env, q: log_query::LogQuery) -> soroban_sdk::BytesN<32> {
         let entries = Self::query(env.clone(), q);
         signing::compute_digest(&env, &entries)
     }

--- a/contracts/audit/src/log_query.rs
+++ b/contracts/audit/src/log_query.rs
@@ -26,12 +26,16 @@ pub struct LogQuery {
     pub actor: Address,
     /// Portfolio filter symbol. Ignored when `filter_portfolio` is false.
     pub portfolio: Symbol,
+    /// Outcome filter symbol. Ignored when `filter_outcome` is false.
+    pub outcome: Symbol,
     /// Whether `event_type` filtering is active.
     pub filter_event_type: bool,
     /// Whether `actor` filtering is active.
     pub filter_actor: bool,
     /// Whether `portfolio` filtering is active.
     pub filter_portfolio: bool,
+    /// Whether `outcome` filtering is active.
+    pub filter_outcome: bool,
     /// Maximum number of entries returned.
     pub limit: u32,
     /// Reserved for future use (e.g. cursor-based pagination).
@@ -48,9 +52,11 @@ impl LogQuery {
             event_type: AuditEventType::Custom,
             actor: dummy_address(env),
             portfolio: symbol_short!(""),
+            outcome: symbol_short!(""),
             filter_event_type: false,
             filter_actor: false,
             filter_portfolio: false,
+            filter_outcome: false,
             limit,
             cursor: 0,
         }
@@ -89,6 +95,13 @@ impl LogQuery {
         self
     }
 
+    /// Restrict the query to a single outcome symbol.
+    pub fn outcome(mut self, o: Symbol) -> Self {
+        self.outcome = o;
+        self.filter_outcome = true;
+        self
+    }
+
     /// Override the maximum number of entries returned.
     pub fn limit(mut self, limit: u32) -> Self {
         self.limit = limit;
@@ -110,6 +123,9 @@ impl LogQuery {
             return false;
         }
         if self.filter_portfolio && entry.portfolio != self.portfolio {
+            return false;
+        }
+        if self.filter_outcome && entry.outcome != self.outcome {
             return false;
         }
         true

--- a/contracts/audit/src/log_query.rs
+++ b/contracts/audit/src/log_query.rs
@@ -5,8 +5,8 @@
 //! append-only primary index and returns every entry that matches with a
 //! cap of `limit`.
 
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 use crate::records::{AuditEventType, AuditLog};
 

--- a/contracts/audit/src/log_query.rs
+++ b/contracts/audit/src/log_query.rs
@@ -6,12 +6,13 @@
 //! cap of `limit`.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::testutils::Address as _;
 
 use crate::records::{AuditEventType, AuditLog};
 
 /// Filter set for log queries.
 ///
-/// Zero-valued / default fields mean "any"; non-zero narrows the search.
+/// `None` / default fields mean "any"; non-default narrows the search.
 /// Boolean flags control which filters are active.
 #[contracttype]
 #[derive(Debug, Clone)]
@@ -22,11 +23,11 @@ pub struct LogQuery {
     pub to_ts: u64,
     /// Event-type filter. Ignored when `filter_event_type` is false.
     pub event_type: AuditEventType,
-    /// Actor filter address. Ignored when `filter_actor` is false.
+    /// Actor filter address. Only used when `filter_actor` is true.
     pub actor: Address,
     /// Portfolio filter symbol. Ignored when `filter_portfolio` is false.
     pub portfolio: Symbol,
-    /// Outcome filter symbol. Ignored when `filter_outcome` is false.
+    /// Outcome filter symbol. Only used when `filter_outcome` is true.
     pub outcome: Symbol,
     /// Whether `event_type` filtering is active.
     pub filter_event_type: bool,
@@ -43,14 +44,17 @@ pub struct LogQuery {
 }
 
 impl LogQuery {
-    /// Build an empty query with a default limit. Uses a dummy address for the
-    /// actor field (it is only consulted when `filter_actor` is true).
+    /// Build an empty query with a default limit.
+    ///
+    /// Uses `Address::generate` for the unused actor field placeholder.
+    /// This placeholder is only stored in the struct and never used for
+    /// comparison when `filter_actor` is false.
     pub fn new(env: &Env, limit: u32) -> Self {
         Self {
             from_ts: 0,
             to_ts: 0,
             event_type: AuditEventType::Custom,
-            actor: dummy_address(env),
+            actor: Address::generate(env),
             portfolio: symbol_short!(""),
             outcome: symbol_short!(""),
             filter_event_type: false,
@@ -130,13 +134,4 @@ impl LogQuery {
         }
         true
     }
-}
-
-/// Create a deterministic dummy address for the unused actor field.
-fn dummy_address(env: &Env) -> Address {
-    // Use the well-known "GA" strkey with 32 zero bytes — a valid but
-    // non-signing address. This is only used as a placeholder when the
-    // actor filter is inactive.
-    let bytes = soroban_sdk::Bytes::from_slice(env, &[0u8; 32]);
-    Address::from_string_bytes(&bytes)
 }

--- a/contracts/audit/src/records.rs
+++ b/contracts/audit/src/records.rs
@@ -46,6 +46,28 @@ pub enum AuditEventType {
     ScheduleChange = 7,
     /// Admin-level configuration change (alert threshold, default APR, etc.).
     AdminAction = 8,
+    /// Portfolio was created or initialized.
+    PortfolioCreated = 9,
+    /// Role granted or revoked (RBAC change).
+    RoleChange = 10,
+    /// Yield claimed by a staker.
+    YieldClaim = 11,
+    /// Governance proposal submitted.
+    GovernanceProposal = 12,
+    /// Governance vote cast.
+    GovernanceVote = 13,
+    /// Treasury withdrawal or spending action.
+    TreasuryAction = 14,
+    /// Emergency pause or unpause.
+    EmergencyPause = 15,
+    /// Trade executed (order matched or batch filled).
+    TradeExecution = 16,
+    /// Order placed on the order book.
+    OrderPlaced = 17,
+    /// Order cancelled from the order book.
+    OrderCancelled = 18,
+    /// Fee collected from a transaction.
+    FeeCollection = 19,
     /// Catch-all for events that don't fit a predefined type.
     Custom = 99,
 }
@@ -180,4 +202,6 @@ pub enum StorageKey {
     IndexByPortfolio(Symbol, u32),
     /// Index of every logged sequence id (1:1 with `Entry(seq)`).
     AllSeqs,
+    /// Bucket index for an outcome secondary lookup.
+    IndexByOutcome(Symbol, u32),
 }

--- a/contracts/audit/src/signing.rs
+++ b/contracts/audit/src/signing.rs
@@ -1,0 +1,115 @@
+//! Cryptographic signing of audit log exports for verification.
+//!
+//! Provides `SignedExport` — a batch of audit entries wrapped with a
+//! SHA-256 digest. Off-chain services sign the digest with ed25519 and
+//! attach the signature. On-chain or off-chain verifiers can recompute
+//! the digest from the raw entries and verify the signature against a
+//! known public key.
+//!
+//! The signing flow (off-chain):
+//!
+//! 1. Call `compute_digest` with a batch of entries.
+//! 2. Sign the resulting digest with ed25519 (off-chain).
+//! 3. Bundle the entries, digest, and signature into `SignedExport`.
+//!
+//! Verification (on-chain or off-chain):
+//!
+//! 1. Re-derive the SHA-256 digest from `SignedExport.entries`.
+//! 2. Verify the ed25519 signature against the digest and the signer's public key.
+//!
+//! Note: Soroban's `ed25519_verify` panics on invalid signatures, aborting
+//! the transaction. This is the secure default for smart contracts. Callers
+//! who need a boolean result should use `compute_digest` and verify off-chain.
+
+use soroban_sdk::{contracttype, Bytes, BytesN, Env, Vec};
+
+use crate::records::AuditLog;
+
+/// A deterministically-ordered, signed export of audit log entries.
+///
+/// `entries` is the raw `Vec<AuditLog>` (from a `query` call).
+/// `digest` is `SHA-256(serialize(entries))`.
+/// `signature` is an ed25519 signature over `digest` (produced off-chain).
+/// `signer` is the public key (32 bytes) that produced the signature.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct SignedExport {
+    /// The raw audit entries.
+    pub entries: Vec<AuditLog>,
+    /// SHA-256 digest of the serialized entries.
+    pub digest: BytesN<32>,
+    /// ed25519 signature over `digest` (64 bytes, produced off-chain).
+    pub signature: BytesN<64>,
+    /// Ed25519 public key of the signer.
+    pub signer: BytesN<32>,
+}
+
+/// Serialize a batch of audit log entries into a deterministic byte payload.
+///
+/// Layout per entry (all big-endian):
+/// - `seq: u64` (8 bytes)
+/// - `timestamp: u64` (8 bytes)
+/// - `event_type as u32` (4 bytes)
+/// - `permissions: u32` (4 bytes)
+/// - `hash: BytesN<32>` (32 bytes)
+///
+/// We serialize only the immutable, compact fields so the payload is
+/// compact and deterministic. The full entry (including strings, state
+/// snapshots, etc.) is included in `SignedExport.entries` for off-chain
+/// consumers.
+pub fn serialize_entries(env: &Env, entries: &Vec<AuditLog>) -> Bytes {
+    let mut buf = Bytes::new(env);
+    // Length prefix (number of entries).
+    let len = entries.len();
+    buf.append(&Bytes::from_array(env, &len.to_be_bytes()));
+    for entry in entries.iter() {
+        buf.append(&Bytes::from_array(env, &entry.seq.to_be_bytes()));
+        buf.append(&Bytes::from_array(env, &entry.timestamp.to_be_bytes()));
+        buf.append(&Bytes::from_array(
+            env,
+            &(entry.event_type as u32).to_be_bytes(),
+        ));
+        buf.append(&Bytes::from_array(env, &entry.permissions.to_be_bytes()));
+        buf.append(&Bytes::from_array(env, &entry.hash.to_array()));
+    }
+    buf
+}
+
+/// Compute the SHA-256 digest of a serialized entry payload.
+///
+/// This is the value that gets signed off-chain and verified on-chain.
+pub fn compute_digest(env: &Env, entries: &Vec<AuditLog>) -> BytesN<32> {
+    let payload = serialize_entries(env, entries);
+    env.crypto().sha256(&payload).into()
+}
+
+/// Verify a [`SignedExport`] against a known public key.
+///
+/// This function verifies that:
+/// 1. The public key matches `export.signer`.
+/// 2. The digest matches `SHA-256(serialize(entries))`.
+/// 3. The signature is valid for the digest under the public key.
+///
+/// # Panics
+///
+/// Panics (aborting the transaction) if the signature is invalid.
+/// This is the secure default for Soroban contracts — callers who need
+/// a boolean result should use `compute_digest` and verify off-chain.
+pub fn verify_export(env: &Env, export: &SignedExport, public_key: &BytesN<32>) {
+    // Check that the public key matches the one in the export.
+    assert!(
+        export.signer == *public_key,
+        "signer public key does not match provided key"
+    );
+    // Recompute the digest from the entries.
+    let expected_digest = compute_digest(env, &export.entries);
+    assert!(
+        expected_digest == export.digest,
+        "digest mismatch: entries may have been tampered with"
+    );
+    // Verify the ed25519 signature (panics on failure).
+    let digest_bytes: Bytes = export.digest.clone().into();
+    let sig_bytes: BytesN<64> = export.signature.clone();
+    env.crypto()
+        .ed25519_verify(public_key, &digest_bytes, &sig_bytes);
+}

--- a/contracts/audit/src/tests.rs
+++ b/contracts/audit/src/tests.rs
@@ -523,3 +523,280 @@ fn test_export_csv_escapes_special_characters() {
     // Field should be wrapped in quotes because it contains a comma.
     assert!(body.contains("\"comma,with\"\"quotes\""));
 }
+
+// ---------------------------------------------------------------------------
+// Outcome filtering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_query_filters_by_outcome() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+    let _ = client.log_event(
+        &s,
+        &AuditEventType::Stake,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, ""),
+    );
+    let _ = client.log_event(
+        &s,
+        &AuditEventType::Stake,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("fail"),
+        &String::from_str(&env, ""),
+    );
+    let ok_entries = client.query(&LogQuery::new(&env, 10).outcome(symbol_short!("ok")));
+    assert_eq!(ok_entries.len(), 1);
+    assert_eq!(ok_entries.get(0).unwrap().outcome, symbol_short!("ok"));
+}
+
+// ---------------------------------------------------------------------------
+// New event types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_new_event_types_logging() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+
+    // Test PortfolioCreated
+    let seq = client.log_event(
+        &s,
+        &AuditEventType::PortfolioCreated,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &happy_snapshot(&env, symbol_short!("val"), 100),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "created"),
+    );
+    assert_eq!(seq, 1);
+
+    // Test GovernanceProposal
+    let seq = client.log_event(
+        &s,
+        &AuditEventType::GovernanceProposal,
+        &symbol_short!("gov"),
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "submitted"),
+    );
+    assert_eq!(seq, 2);
+
+    // Test TradeExecution
+    let seq = client.log_event(
+        &s,
+        &AuditEventType::TradeExecution,
+        &symbol_short!("XLM_USDC"),
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "filled"),
+    );
+    assert_eq!(seq, 3);
+
+    // Query by new event types
+    let gov_entries = client.query(
+        &LogQuery::new(&env, 10).event_type(AuditEventType::GovernanceProposal),
+    );
+    assert_eq!(gov_entries.len(), 1);
+    assert_eq!(gov_entries.get(0).unwrap().event_type, AuditEventType::GovernanceProposal);
+
+    let trade_entries = client.query(
+        &LogQuery::new(&env, 10).event_type(AuditEventType::TradeExecution),
+    );
+    assert_eq!(trade_entries.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Full export with state snapshots and hash
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_export_jsonl_full_includes_hash() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+    let _ = client.log_event(
+        &s,
+        &AuditEventType::Stake,
+        &a,
+        &permissions::STAKER,
+        &happy_snapshot(&env, a.clone(), 0),
+        &happy_snapshot(&env, a.clone(), 100),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "stake"),
+    );
+    let rows = client.export_jsonl_full(&LogQuery::new(&env, 10));
+    assert_eq!(rows.len(), 1);
+    let row = soroban_str_to_rust(&rows.get(0).unwrap());
+    assert!(row.contains("\"hash\""));
+    assert!(row.contains("\"state_before\""));
+    assert!(row.contains("\"state_after\""));
+}
+
+#[test]
+fn test_export_csv_full_includes_state() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+    let _ = client.log_event(
+        &s,
+        &AuditEventType::Stake,
+        &a,
+        &permissions::STAKER,
+        &happy_snapshot(&env, a.clone(), 0),
+        &happy_snapshot(&env, a.clone(), 500),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "deposit"),
+    );
+    let rows = client.export_csv_full(&LogQuery::new(&env, 10));
+    assert_eq!(rows.len(), 2);
+    let header = soroban_str_to_rust(&rows.get(0).unwrap());
+    assert!(header.contains("hash"));
+    assert!(header.contains("state_before"));
+    assert!(header.contains("state_after"));
+    let body = soroban_str_to_rust(&rows.get(1).unwrap());
+    assert!(body.contains("XLM"));
+}
+
+// ---------------------------------------------------------------------------
+// Signing / digest computation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compute_export_digest() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+    let _ = client.log_event(
+        &s,
+        &AuditEventType::Stake,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "test"),
+    );
+    let digest = client.compute_export_digest(&LogQuery::new(&env, 10));
+    // Digest should be non-zero
+    assert_ne!(digest, soroban_sdk::BytesN::from_array(&env, &[0u8; 32]));
+}
+
+#[test]
+fn test_new_event_type_names() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let a = asset();
+    // Log each new event type
+    let seq = client.log_event(
+        &s, &AuditEventType::PortfolioCreated, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "PortfolioCreated"),
+    );
+    assert_eq!(seq, 1);
+    let seq = client.log_event(
+        &s, &AuditEventType::RoleChange, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "RoleChange"),
+    );
+    assert_eq!(seq, 2);
+    let seq = client.log_event(
+        &s, &AuditEventType::YieldClaim, &a, &permissions::STAKER,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "YieldClaim"),
+    );
+    assert_eq!(seq, 3);
+    let seq = client.log_event(
+        &s, &AuditEventType::GovernanceProposal, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "GovernanceProposal"),
+    );
+    assert_eq!(seq, 4);
+    let seq = client.log_event(
+        &s, &AuditEventType::GovernanceVote, &a, &permissions::STAKER,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "GovernanceVote"),
+    );
+    assert_eq!(seq, 5);
+    let seq = client.log_event(
+        &s, &AuditEventType::TreasuryAction, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "TreasuryAction"),
+    );
+    assert_eq!(seq, 6);
+    let seq = client.log_event(
+        &s, &AuditEventType::EmergencyPause, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "EmergencyPause"),
+    );
+    assert_eq!(seq, 7);
+    let seq = client.log_event(
+        &s, &AuditEventType::TradeExecution, &a, &permissions::STAKER,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "TradeExecution"),
+    );
+    assert_eq!(seq, 8);
+    let seq = client.log_event(
+        &s, &AuditEventType::OrderPlaced, &a, &permissions::STAKER,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "OrderPlaced"),
+    );
+    assert_eq!(seq, 9);
+    let seq = client.log_event(
+        &s, &AuditEventType::OrderCancelled, &a, &permissions::STAKER,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "OrderCancelled"),
+    );
+    assert_eq!(seq, 10);
+    let seq = client.log_event(
+        &s, &AuditEventType::FeeCollection, &a, &permissions::ADMIN,
+        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
+        &symbol_short!("ok"), &String::from_str(&env, "FeeCollection"),
+    );
+    assert_eq!(seq, 11);
+    // Verify all logged
+    let all = client.query(&LogQuery::new(&env, 50));
+    assert_eq!(all.len(), 11);
+}
+
+#[test]
+fn test_log_event_with_full_state_snapshots() {
+    let (env, client, _admin) = setup();
+    let s = staker(&env);
+    let mut before = StateSnapshot::empty(&env);
+    before.push(symbol_short!("XLM"), 1000);
+    before.push(symbol_short!("USDC"), 5000);
+    let mut after = StateSnapshot::empty(&env);
+    after.push(symbol_short!("XLM"), 800);
+    after.push(symbol_short!("USDC"), 6000);
+    let seq = client.log_event(
+        &s,
+        &AuditEventType::Rebalance,
+        &symbol_short!("PORT1"),
+        &permissions::ADMIN,
+        &before,
+        &after,
+        &symbol_short!("ok"),
+        &String::from_str(&env, "rebalanced"),
+    );
+    assert_eq!(seq, 1);
+    let entry = client.query(&LogQuery::new(&env, 10)).get(0).unwrap();
+    assert_eq!(entry.state_before.fields.len(), 2);
+    assert_eq!(entry.state_after.fields.len(), 2);
+    assert_eq!(entry.state_after.fields.get(0).unwrap().value, 800);
+    assert_eq!(entry.state_after.fields.get(1).unwrap().value, 6000);
+}

--- a/contracts/audit/src/tests.rs
+++ b/contracts/audit/src/tests.rs
@@ -608,15 +608,16 @@ fn test_new_event_types_logging() {
     assert_eq!(seq, 3);
 
     // Query by new event types
-    let gov_entries = client.query(
-        &LogQuery::new(&env, 10).event_type(AuditEventType::GovernanceProposal),
-    );
+    let gov_entries =
+        client.query(&LogQuery::new(&env, 10).event_type(AuditEventType::GovernanceProposal));
     assert_eq!(gov_entries.len(), 1);
-    assert_eq!(gov_entries.get(0).unwrap().event_type, AuditEventType::GovernanceProposal);
-
-    let trade_entries = client.query(
-        &LogQuery::new(&env, 10).event_type(AuditEventType::TradeExecution),
+    assert_eq!(
+        gov_entries.get(0).unwrap().event_type,
+        AuditEventType::GovernanceProposal
     );
+
+    let trade_entries =
+        client.query(&LogQuery::new(&env, 10).event_type(AuditEventType::TradeExecution));
     assert_eq!(trade_entries.len(), 1);
 }
 
@@ -703,69 +704,124 @@ fn test_new_event_type_names() {
     let a = asset();
     // Log each new event type
     let seq = client.log_event(
-        &s, &AuditEventType::PortfolioCreated, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "PortfolioCreated"),
+        &s,
+        &AuditEventType::PortfolioCreated,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "PortfolioCreated"),
     );
     assert_eq!(seq, 1);
     let seq = client.log_event(
-        &s, &AuditEventType::RoleChange, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "RoleChange"),
+        &s,
+        &AuditEventType::RoleChange,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "RoleChange"),
     );
     assert_eq!(seq, 2);
     let seq = client.log_event(
-        &s, &AuditEventType::YieldClaim, &a, &permissions::STAKER,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "YieldClaim"),
+        &s,
+        &AuditEventType::YieldClaim,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "YieldClaim"),
     );
     assert_eq!(seq, 3);
     let seq = client.log_event(
-        &s, &AuditEventType::GovernanceProposal, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "GovernanceProposal"),
+        &s,
+        &AuditEventType::GovernanceProposal,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "GovernanceProposal"),
     );
     assert_eq!(seq, 4);
     let seq = client.log_event(
-        &s, &AuditEventType::GovernanceVote, &a, &permissions::STAKER,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "GovernanceVote"),
+        &s,
+        &AuditEventType::GovernanceVote,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "GovernanceVote"),
     );
     assert_eq!(seq, 5);
     let seq = client.log_event(
-        &s, &AuditEventType::TreasuryAction, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "TreasuryAction"),
+        &s,
+        &AuditEventType::TreasuryAction,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "TreasuryAction"),
     );
     assert_eq!(seq, 6);
     let seq = client.log_event(
-        &s, &AuditEventType::EmergencyPause, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "EmergencyPause"),
+        &s,
+        &AuditEventType::EmergencyPause,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "EmergencyPause"),
     );
     assert_eq!(seq, 7);
     let seq = client.log_event(
-        &s, &AuditEventType::TradeExecution, &a, &permissions::STAKER,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "TradeExecution"),
+        &s,
+        &AuditEventType::TradeExecution,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "TradeExecution"),
     );
     assert_eq!(seq, 8);
     let seq = client.log_event(
-        &s, &AuditEventType::OrderPlaced, &a, &permissions::STAKER,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "OrderPlaced"),
+        &s,
+        &AuditEventType::OrderPlaced,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "OrderPlaced"),
     );
     assert_eq!(seq, 9);
     let seq = client.log_event(
-        &s, &AuditEventType::OrderCancelled, &a, &permissions::STAKER,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "OrderCancelled"),
+        &s,
+        &AuditEventType::OrderCancelled,
+        &a,
+        &permissions::STAKER,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "OrderCancelled"),
     );
     assert_eq!(seq, 10);
     let seq = client.log_event(
-        &s, &AuditEventType::FeeCollection, &a, &permissions::ADMIN,
-        &StateSnapshot::empty(&env), &StateSnapshot::empty(&env),
-        &symbol_short!("ok"), &String::from_str(&env, "FeeCollection"),
+        &s,
+        &AuditEventType::FeeCollection,
+        &a,
+        &permissions::ADMIN,
+        &StateSnapshot::empty(&env),
+        &StateSnapshot::empty(&env),
+        &symbol_short!("ok"),
+        &String::from_str(&env, "FeeCollection"),
     );
     assert_eq!(seq, 11);
     // Verify all logged

--- a/contracts/audit/src/tests.rs
+++ b/contracts/audit/src/tests.rs
@@ -9,9 +9,9 @@
 //! - JSON/CSV export formatting.
 
 use super::*;
-use crate::checksum::{chain_hash, entry_payload, first_chain_hash};
+use crate::checksum::{entry_payload, first_chain_hash};
 use crate::log_query::LogQuery;
-use crate::records::{permissions, AuditEventType, FieldEntry, RetentionPolicy, StateSnapshot};
+use crate::records::{permissions, AuditEventType, RetentionPolicy, StateSnapshot};
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol, Vec};
 
@@ -244,7 +244,7 @@ fn test_query_filters_by_portfolio() {
         &symbol_short!("ok"),
         &String::from_str(&env, ""),
     );
-    let only_xlm = client.query(&LogQuery::new(&env, 10).portfolio(xlm));
+    let only_xlm = client.query(&LogQuery::new(&env, 10).portfolio(xlm.clone()));
     assert_eq!(only_xlm.len(), 1);
     assert_eq!(only_xlm.get(0).unwrap().portfolio, xlm);
 }
@@ -445,10 +445,9 @@ fn soroban_str_to_rust(s: &String) -> alloc::string::String {
     if len == 0 {
         return alloc::string::String::new();
     }
-    let mut buf = [0u8; 256];
-    let slice_len = len.min(256);
-    s.copy_into_slice(&mut buf[..slice_len]);
-    alloc::string::String::from_utf8(buf[..slice_len].to_vec()).unwrap_or_default()
+    let mut buf = alloc::vec![0u8; len];
+    s.copy_into_slice(&mut buf);
+    alloc::string::String::from_utf8(buf).unwrap_or_default()
 }
 
 #[test]
@@ -520,7 +519,7 @@ fn test_export_csv_escapes_special_characters() {
         &String::from_str(&env, "comma,with\"quotes"),
     );
     let rows = client.export_csv(&LogQuery::new(&env, 10));
-    let body = rows.get(1).unwrap().to_string();
+    let body = soroban_str_to_rust(&rows.get(1).unwrap());
     // Field should be wrapped in quotes because it contains a comma.
-    assert!(body.contains("\"comma,\"\"with\"\"quotes\""));
+    assert!(body.contains("\"comma,with\"\"quotes\""));
 }

--- a/contracts/emergency/Cargo.toml
+++ b/contracts/emergency/Cargo.toml
@@ -6,9 +6,11 @@ authors.workspace = true
 license.workspace = true
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+astraport-audit = { path = "../audit" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/emergency/src/lib.rs
+++ b/contracts/emergency/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
 };
 
+use astraport_audit::logger::AuditLogger;
+use astraport_audit::records::{permissions, AuditEventType, StateSnapshot};
+
 // ============================================================================
 // Storage Key Symbols
 // ============================================================================
@@ -23,6 +26,7 @@ const RATE_LIMITS: Symbol = symbol_short!("RT_LT");
 const RATE_COUNTERS: Symbol = symbol_short!("RT_CN");
 const NOTIFIERS: Symbol = symbol_short!("NOTF");
 const LOCK_PERIOD: Symbol = symbol_short!("LCK_P");
+const AUDIT_SINK: Symbol = symbol_short!("AUD_S");
 
 // ============================================================================
 // Limits & Constants
@@ -378,6 +382,53 @@ impl EmergencyControls {
         symbol_short!("ok")
     }
 
+    /// Configure the audit-log sink address. Admin-only.
+    pub fn set_audit_sink(env: Env, sink: Address) -> Symbol {
+        let admin = require_admin(&env);
+        env.storage().persistent().set(&AUDIT_SINK, &sink);
+
+        append_incident(
+            &env,
+            IncidentActionType::ConfigUpdated,
+            IncidentSeverity::Medium,
+            &admin,
+            symbol_short!("AUD_S"),
+            0,
+        );
+
+        symbol_short!("ok")
+    }
+
+    /// Read the audit-log sink address, if configured.
+    pub fn get_audit_sink(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&AUDIT_SINK)
+    }
+
+    /// Log an audit event if a sink is configured. No-op otherwise.
+    fn log_audit_if_configured(
+        env: &Env,
+        actor: &Address,
+        event_type: AuditEventType,
+        outcome: Symbol,
+        detail: &str,
+    ) {
+        let sink: Option<Address> = env.storage().persistent().get(&AUDIT_SINK);
+        if let Some(sink) = sink {
+            let detail_str = soroban_sdk::String::from_str(env, detail);
+            let logger = AuditLogger::new(env, &sink);
+            let _ = logger.log_event(
+                actor.clone(),
+                event_type,
+                symbol_short!("emerg"),
+                permissions::ADMIN,
+                StateSnapshot::empty(env),
+                StateSnapshot::empty(env),
+                outcome,
+                detail_str,
+            );
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Pause / Resume
     // -----------------------------------------------------------------------
@@ -409,6 +460,14 @@ impl EmergencyControls {
             0,
         );
 
+        Self::log_audit_if_configured(
+            &env,
+            &caller,
+            AuditEventType::EmergencyPause,
+            symbol_short!("ok"),
+            &"pause_activated",
+        );
+
         env.events()
             .publish((symbol_short!("PAUSE"), &caller), &reason);
 
@@ -433,6 +492,14 @@ impl EmergencyControls {
             &admin,
             reason.clone(),
             0,
+        );
+
+        Self::log_audit_if_configured(
+            &env,
+            &admin,
+            AuditEventType::EmergencyPause,
+            symbol_short!("ok"),
+            &"pause_deactivated",
         );
 
         env.events()
@@ -478,6 +545,14 @@ impl EmergencyControls {
             &user,
             symbol_short!("EM_WD"),
             amount,
+        );
+
+        Self::log_audit_if_configured(
+            &env,
+            &user,
+            AuditEventType::EmergencyUnstake,
+            symbol_short!("ok"),
+            &"emergency_withdrawal",
         );
 
         env.events().publish(

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -553,6 +553,14 @@ impl GovernanceDAO {
             &title,
         );
 
+        Self::log_audit_if_configured(
+            &env,
+            &proposer,
+            proposal_id,
+            symbol_short!("ok"),
+            &"proposal_submitted",
+        );
+
         env.events().publish(
             (symbol_short!("PROPOSAL"), &proposer),
             ProposalEvent {
@@ -757,6 +765,14 @@ impl GovernanceDAO {
             proposal_id,
             &voter,
             &symbol_short!("cast"),
+        );
+
+        Self::log_audit_if_configured(
+            &env,
+            &voter,
+            proposal_id,
+            symbol_short!("ok"),
+            &"vote_cast",
         );
 
         env.events().publish(
@@ -1407,6 +1423,14 @@ impl GovernanceDAO {
             &symbol_short!("paused"),
         );
 
+        Self::log_audit_if_configured(
+            &env,
+            &caller,
+            0,
+            symbol_short!("ok"),
+            &"emergency_pause",
+        );
+
         env.events()
             .publish((symbol_short!("EM_PAUSE"), &caller), OK);
 
@@ -1861,7 +1885,6 @@ impl GovernanceDAO {
     }
 
     /// Integration with the audit-log contract.
-    #[allow(dead_code)]
     fn log_audit_if_configured(
         env: &Env,
         actor: &Address,

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -767,13 +767,7 @@ impl GovernanceDAO {
             &symbol_short!("cast"),
         );
 
-        Self::log_audit_if_configured(
-            &env,
-            &voter,
-            proposal_id,
-            symbol_short!("ok"),
-            &"vote_cast",
-        );
+        Self::log_audit_if_configured(&env, &voter, proposal_id, symbol_short!("ok"), &"vote_cast");
 
         env.events().publish(
             (symbol_short!("VOTE"), &voter),
@@ -1423,13 +1417,7 @@ impl GovernanceDAO {
             &symbol_short!("paused"),
         );
 
-        Self::log_audit_if_configured(
-            &env,
-            &caller,
-            0,
-            symbol_short!("ok"),
-            &"emergency_pause",
-        );
+        Self::log_audit_if_configured(&env, &caller, 0, symbol_short!("ok"), &"emergency_pause");
 
         env.events()
             .publish((symbol_short!("EM_PAUSE"), &caller), OK);

--- a/contracts/trade/Cargo.toml
+++ b/contracts/trade/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+astraport-audit = { path = "../audit" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/trade/src/lib.rs
+++ b/contracts/trade/src/lib.rs
@@ -15,7 +15,10 @@
 //! - [`engine`] — Atomic batch execution: multi-leg settlement that rolls
 //!   back entirely on any failure.
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol, Vec};
+
+use astraport_audit::logger::AuditLogger;
+use astraport_audit::records::{permissions, AuditEventType, StateSnapshot};
 
 pub mod engine;
 pub mod orderbook;
@@ -163,7 +166,20 @@ impl TradeEngine {
             return Err(TradeError::InvalidOrderAmount);
         }
 
-        ob::place_order(&env, &pair_id, &owner, side, price, amount)
+        let order_id = ob::place_order(&env, &pair_id, &owner, side, price, amount)?;
+
+        Self::log_audit_if_configured(
+            &env,
+            &owner,
+            &pair_id,
+            AuditEventType::OrderPlaced,
+            0,
+            amount,
+            symbol_short!("ok"),
+            &"order_placed",
+        );
+
+        Ok(order_id)
     }
 
     /// Cancel an order.  Only the order owner or admin may cancel.
@@ -177,6 +193,17 @@ impl TradeEngine {
 
         let is_admin = Self::assert_admin(&env, &caller).is_ok();
         ob::cancel_order(&env, &pair_id, order_id, &caller, is_admin)?;
+
+        Self::log_audit_if_configured(
+            &env,
+            &caller,
+            &pair_id,
+            AuditEventType::OrderCancelled,
+            0,
+            0,
+            symbol_short!("ok"),
+            &"order_cancelled",
+        );
 
         env.events()
             .publish((symbol_short!("ORDCNCL"), pair_id, order_id), caller);
@@ -253,6 +280,17 @@ impl TradeEngine {
             );
         }
 
+        Self::log_audit_if_configured(
+            &env,
+            &user,
+            &symbol_short!("BATCH"),
+            AuditEventType::TradeExecution,
+            0,
+            result.total_fills as i128,
+            symbol_short!("ok"),
+            &"batch_executed",
+        );
+
         env.events().publish(
             (symbol_short!("BATCH_OK"), user.clone()),
             (result.total_fills, result.legs.len()),
@@ -315,6 +353,54 @@ impl TradeEngine {
             return Err(TradeError::Unauthorized);
         }
         Ok(())
+    }
+
+    /// Configure the audit-log sink address. Admin-only.
+    pub fn set_audit_sink(env: Env, admin: Address, sink: Address) -> Result<Symbol, TradeError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .set(&TradeDataKey::AuditSink, &sink);
+        Ok(symbol_short!("ok"))
+    }
+
+    /// Read the audit-log sink address, if configured.
+    pub fn get_audit_sink(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&TradeDataKey::AuditSink)
+    }
+
+    /// Append an audit event if a sink is configured. No-op otherwise.
+    fn log_audit_if_configured(
+        env: &Env,
+        actor: &Address,
+        pair_id: &Symbol,
+        event_type: AuditEventType,
+        before_balance: i128,
+        after_balance: i128,
+        outcome: Symbol,
+        detail: &str,
+    ) {
+        let key = TradeDataKey::AuditSink;
+        let sink: Option<Address> = env.storage().persistent().get(&key);
+        if let Some(sink) = sink {
+            let mut before = StateSnapshot::empty(env);
+            before.push(pair_id.clone(), before_balance);
+            let mut after = StateSnapshot::empty(env);
+            after.push(pair_id.clone(), after_balance);
+            let detail_str = soroban_sdk::String::from_str(env, detail);
+            let logger = AuditLogger::new(env, &sink);
+            let _ = logger.log_event(
+                actor.clone(),
+                event_type,
+                pair_id.clone(),
+                permissions::STAKER,
+                before,
+                after,
+                outcome,
+                detail_str,
+            );
+        }
     }
 }
 

--- a/contracts/trade/src/types.rs
+++ b/contracts/trade/src/types.rs
@@ -112,6 +112,8 @@ pub enum TradeDataKey {
     PairVolume(Symbol),
     /// Registered pair list.
     PairList,
+    /// Optional audit-log sink address.
+    AuditSink,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #42


## Description

### Summary

Implement an immutable audit logging system that records all significant contract operations for compliance, debugging, and security investigation purposes. The system extends the existing audit contract with 11 new event types, outcome-based filtering, cryptographic log signing, enhanced exports with state snapshots and chain hashes, and cross-contract audit integration across governance, trade, and emergency contracts.

### Changes

**Core Audit Contract (`contracts/audit/`)**

- **11 new `AuditEventType` variants**: `PortfolioCreated`, `RoleChange`, `YieldClaim`, `GovernanceProposal`, `GovernanceVote`, `TreasuryAction`, `EmergencyPause`, `TradeExecution`, `OrderPlaced`, `OrderCancelled`, `FeeCollection`
- **Outcome filtering** on `LogQuery` — query by success/failure outcome alongside existing portfolio, actor, event type, and time range filters
- **`IndexByOutcome` secondary index** for efficient outcome-based queries
- **`signing` module** — SHA-256 digest computation for entries, ed25519 signature verification via `verify_export()`, and `SignedExport` struct for cryptographic audit export verification
- **Enhanced exports** — `export_jsonl_full()` and `export_csv_full()` include state snapshots, hex-encoded chain hashes; standard exports now include the hash column
- **`compute_export_digest()`** contract entrypoint for off-chain signing workflows
- **Fixed pre-existing bugs** — `LogQuery` dummy address creation (invalid Soroban strkey), CSV escape assertion, JSONL buffer overflow in tests

**Governance Contract (`contracts/governance/`)**

- Activated `log_audit_if_configured()` calls for proposal submissions, vote casting, and emergency pause/unpause operations

**Trade Contract (`contracts/trade/`)**

- Added `set_audit_sink()` / `get_audit_sink()` endpoints
- Added `log_audit_if_configured()` for order placement, order cancellation, and atomic batch execution

**Emergency Contract (`contracts/emergency/`)**

- Added `set_audit_sink()` / `get_audit_sink()` endpoints
- Added `log_audit_if_configured()` for pause, unpause, and emergency withdrawal operations

### Acceptance Criteria Coverage

| Criterion | Status |
|---|---|
| All significant operations are logged automatically | ✅ Stake, unstake, rebalance, governance, trade, emergency operations |
| Audit logs include operation type, actor, timestamp, and outcome | ✅ `AuditLog` struct with all fields + chain hash |
| Logs are immutable (cannot be modified or deleted) | ✅ SHA-256 chain hash with tamper detection |
| Logs can be queried by portfolio, actor, time range, and operation type | ✅ `LogQuery` with 5 filter dimensions |
| Audit log storage is efficient and does not impact performance | ✅ Bucket-indexed secondary indexes |
| Export functionality provides human-readable audit reports | ✅ JSONL, CSV, full CSV/JSON with state snapshots |
| Retention policies are configurable | ✅ `RetentionPolicy` with max entries and max age |
| Tests verify logging completeness and query accuracy | ✅ 27 tests covering all features |

### Files Changed (15 files, ~811 insertions)

```
contracts/audit/src/records.rs       |  24 +++  — new event types, IndexByOutcome
contracts/audit/src/log_query.rs     |  42 ±   — outcome filter, fixed dummy address
contracts/audit/src/signing.rs       | 115 +++  — new: cryptographic signing module
contracts/audit/src/export.rs        | 127 ++  — full exports, hash hex-encoding
contracts/audit/src/lib.rs           |  43 ++  — new entrypoints, outcome indexing
contracts/audit/src/tests.rs         | 294 ++  — 7 new tests, fixed pre-existing bugs
contracts/audit/Cargo.toml           |   2 ±  — added testutils feature
contracts/governance/src/lib.rs      |  25 ++  — audit logging for proposals/votes
contracts/trade/src/lib.rs           |  90 ++  — audit sink + order lifecycle logging
contracts/trade/src/types.rs         |   2 ±  — AuditSink storage key
contracts/trade/Cargo.toml           |   1 +  — added audit dependency
contracts/emergency/src/lib.rs       |  75 ++  — audit sink + incident logging
contracts/emergency/Cargo.toml       |   2 ±  — added audit dependency + lib config
```

### Test Results

```
running 27 tests
test result: ok. 27 passed; 0 failed; 0 ignored
```