### PR TITLE
## [Staking] Persist alert thresholds and emit breach alerts

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -863,7 +863,9 @@ impl StakingContract {
 
     /// Return the current alert threshold, if set.
     pub fn get_alert_threshold(env: Env) -> Option<i128> {
-        env.storage().persistent().get(&YieldDataKey::AlertThreshold)
+        env.storage()
+            .persistent()
+            .get(&YieldDataKey::AlertThreshold)
     }
 
     /// Reconfigure the default APR and compounding mode for new yield positions.

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -335,12 +335,15 @@ impl StakingContract {
         env.events().publish(
             (symbol_short!("stake"), staker.clone()),
             StakeEvent {
-                staker,
-                asset,
+                staker: staker.clone(),
+                asset: asset.clone(),
                 amount,
                 new_balance,
             },
         );
+
+        Self::check_balance_threshold(&env, &staker, &asset, new_balance);
+
         Ok(symbol_short!("ok"))
     }
 
@@ -496,12 +499,15 @@ impl StakingContract {
         env.events().publish(
             (symbol_short!("unstake"), staker.clone()),
             UnstakeEvent {
-                staker,
-                asset,
+                staker: staker.clone(),
+                asset: asset.clone(),
                 amount,
                 new_balance,
             },
         );
+
+        Self::check_balance_threshold(&env, &staker, &asset, new_balance);
+
         Ok(symbol_short!("ok"))
     }
 
@@ -853,6 +859,11 @@ impl StakingContract {
             .persistent()
             .set(&YieldDataKey::AlertThreshold, &threshold);
         Ok(symbol_short!("ok"))
+    }
+
+    /// Return the current alert threshold, if set.
+    pub fn get_alert_threshold(env: Env) -> Option<i128> {
+        env.storage().persistent().get(&YieldDataKey::AlertThreshold)
     }
 
     /// Reconfigure the default APR and compounding mode for new yield positions.
@@ -1291,6 +1302,38 @@ impl StakingContract {
                     .persistent()
                     .set(&count_key, &count.saturating_sub(1));
             }
+        }
+    }
+}
+
+/// Balance-threshold alert helpers.
+impl StakingContract {
+    /// Compare `balance` against the persisted alert threshold for
+    /// `(staker, asset)`. If the threshold is set and the balance is
+    /// below it, publish an [`alerts::AlertEvent`].
+    fn check_balance_threshold(env: &Env, staker: &Address, asset: &Symbol, balance: i128) {
+        let threshold: i128 = match env
+            .storage()
+            .persistent()
+            .get(&YieldDataKey::AlertThreshold)
+        {
+            Some(t) => t,
+            None => return,
+        };
+        if balance < threshold {
+            env.events().publish(
+                (symbol_short!("ALERT"), staker.clone(), asset.clone()),
+                alerts::AlertEvent {
+                    staker: staker.clone(),
+                    asset: asset.clone(),
+                    kind: alerts::AlertKind::BalanceDrop,
+                    severity: alerts::AlertSeverity::Critical,
+                    fired_at: env.ledger().timestamp(),
+                    threshold_value: threshold,
+                    observed_value: balance,
+                    label: soroban_sdk::String::from_str(env, "balance_below_threshold"),
+                },
+            );
         }
     }
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -9,8 +9,20 @@
 //! - staking position management and state transition tests.
 
 use super::*;
-use soroban_sdk::testutils::{Address as _, Ledger};
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::testutils::{Address as _, Events, Ledger};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, TryFromVal, Vec};
+
+/// Check if any topic in a Soroban `Vec<Val>` matches the given symbol.
+fn topics_contain_symbol(topics: &Vec<soroban_sdk::Val>, env: &Env, sym: Symbol) -> bool {
+    for i in 0..topics.len() {
+        if let Ok(topic_sym) = Symbol::try_from_val(env, &topics.get(i).unwrap()) {
+            if topic_sym == sym {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 use crate::emergency::PenaltyDecayFunction;
 use crate::fixed_point::{SCALE, SECONDS_PER_DAY, SECONDS_PER_YEAR};
@@ -2100,4 +2112,143 @@ fn test_emergency_config_query_after_stake() {
         cfg.decay_function,
         PenaltyDecayFunction::Exponential
     ));
+}
+
+// ===========================================================================
+// Alert Threshold Tests
+// ===========================================================================
+
+/// Helper: count how many events in `env` have `ALERT` as their first topic.
+fn count_alert_events(env: &Env) -> u32 {
+    let events = env.events().all();
+    let alert_sym = symbol_short!("ALERT");
+    let mut count = 0u32;
+    for i in 0..events.len() {
+        let (_contract_id, topics, _data) = events.get(i).unwrap();
+        if topics_contain_symbol(&topics, env, alert_sym.clone()) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Helper: return the deserialized `AlertEvent` data from the n-th ALERT event (0-based).
+fn nth_alert_event(env: &Env, n: u32) -> crate::alerts::AlertEvent {
+    let events = env.events().all();
+    let alert_sym = symbol_short!("ALERT");
+    let mut seen = 0u32;
+    for i in 0..events.len() {
+        let (_contract_id, topics, data) = events.get(i).unwrap();
+        if topics_contain_symbol(&topics, env, alert_sym.clone()) {
+            if seen == n {
+                return crate::alerts::AlertEvent::try_from_val(env, &data)
+                    .expect("failed to deserialize AlertEvent");
+            }
+            seen += 1;
+        }
+    }
+    panic!("not enough ALERT events; requested #{n} but only {seen} found");
+}
+
+#[test]
+fn test_get_alert_threshold_initially_none() {
+    let (_env, client) = setup();
+    assert_eq!(client.get_alert_threshold(), None);
+}
+
+#[test]
+fn test_set_and_get_alert_threshold() {
+    let (_env, client, admin) = setup_with_admin();
+    client.set_alert_threshold(&admin, &5_000);
+    assert_eq!(client.get_alert_threshold(), Some(5_000));
+}
+
+#[test]
+fn test_stake_below_threshold_emits_alert_event() {
+    let (env, client, admin) = setup_with_admin();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.set_alert_threshold(&admin, &1_000);
+    client.stake(&staker, &asset, &500, &UnlockSchedule::Immediate, &false);
+    assert_eq!(client.get_balance(&staker, &asset), 500);
+
+    assert_eq!(count_alert_events(&env), 1, "expected exactly one ALERT event");
+
+    let event = nth_alert_event(&env, 0);
+    assert_eq!(event.staker, staker);
+    assert_eq!(event.asset, asset);
+    assert_eq!(event.kind, crate::alerts::AlertKind::BalanceDrop);
+    assert_eq!(event.severity, crate::alerts::AlertSeverity::Critical);
+    assert_eq!(event.threshold_value, 1_000);
+    assert_eq!(event.observed_value, 500);
+}
+
+#[test]
+fn test_stake_above_threshold_no_alert_event() {
+    let (env, client, admin) = setup_with_admin();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.set_alert_threshold(&admin, &500);
+    client.stake(&staker, &asset, &1_000, &UnlockSchedule::Immediate, &false);
+
+    assert_eq!(count_alert_events(&env), 0, "expected no ALERT events");
+}
+
+#[test]
+fn test_unstake_below_threshold_emits_alert_event() {
+    let (env, client, admin) = setup_with_admin();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.set_alert_threshold(&admin, &800);
+    client.stake(&staker, &asset, &1_000, &UnlockSchedule::Immediate, &false);
+    client.unstake(&staker, &asset, &300);
+    assert_eq!(client.get_balance(&staker, &asset), 700);
+
+    // Stake was above threshold, unstake brought it below → exactly 1 alert.
+    assert_eq!(count_alert_events(&env), 1, "expected exactly one ALERT event");
+
+    let event = nth_alert_event(&env, 0);
+    assert_eq!(event.kind, crate::alerts::AlertKind::BalanceDrop);
+    assert_eq!(event.threshold_value, 800);
+    assert_eq!(event.observed_value, 700);
+}
+
+#[test]
+fn test_unstake_above_threshold_no_alert_event() {
+    let (env, client, admin) = setup_with_admin();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.set_alert_threshold(&admin, &100);
+    client.stake(&staker, &asset, &1_000, &UnlockSchedule::Immediate, &false);
+    client.unstake(&staker, &asset, &300);
+
+    assert_eq!(count_alert_events(&env), 0, "expected no ALERT events");
+}
+
+#[test]
+fn test_no_threshold_no_alert_event() {
+    let (env, client) = setup();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.stake(&staker, &asset, &1_000, &UnlockSchedule::Immediate, &false);
+    client.unstake(&staker, &asset, &999);
+
+    assert_eq!(count_alert_events(&env), 0, "expected no ALERT events without threshold");
+}
+
+#[test]
+fn test_stake_at_exact_threshold_no_alert() {
+    let (env, client, admin) = setup_with_admin();
+    let staker = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+
+    client.set_alert_threshold(&admin, &500);
+    client.stake(&staker, &asset, &500, &UnlockSchedule::Immediate, &false);
+
+    assert_eq!(count_alert_events(&env), 0, "balance == threshold should not trigger alert");
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -2173,7 +2173,11 @@ fn test_stake_below_threshold_emits_alert_event() {
     client.stake(&staker, &asset, &500, &UnlockSchedule::Immediate, &false);
     assert_eq!(client.get_balance(&staker, &asset), 500);
 
-    assert_eq!(count_alert_events(&env), 1, "expected exactly one ALERT event");
+    assert_eq!(
+        count_alert_events(&env),
+        1,
+        "expected exactly one ALERT event"
+    );
 
     let event = nth_alert_event(&env, 0);
     assert_eq!(event.staker, staker);
@@ -2208,7 +2212,11 @@ fn test_unstake_below_threshold_emits_alert_event() {
     assert_eq!(client.get_balance(&staker, &asset), 700);
 
     // Stake was above threshold, unstake brought it below → exactly 1 alert.
-    assert_eq!(count_alert_events(&env), 1, "expected exactly one ALERT event");
+    assert_eq!(
+        count_alert_events(&env),
+        1,
+        "expected exactly one ALERT event"
+    );
 
     let event = nth_alert_event(&env, 0);
     assert_eq!(event.kind, crate::alerts::AlertKind::BalanceDrop);
@@ -2238,7 +2246,11 @@ fn test_no_threshold_no_alert_event() {
     client.stake(&staker, &asset, &1_000, &UnlockSchedule::Immediate, &false);
     client.unstake(&staker, &asset, &999);
 
-    assert_eq!(count_alert_events(&env), 0, "expected no ALERT events without threshold");
+    assert_eq!(
+        count_alert_events(&env),
+        0,
+        "expected no ALERT events without threshold"
+    );
 }
 
 #[test]
@@ -2250,5 +2262,9 @@ fn test_stake_at_exact_threshold_no_alert() {
     client.set_alert_threshold(&admin, &500);
     client.stake(&staker, &asset, &500, &UnlockSchedule::Immediate, &false);
 
-    assert_eq!(count_alert_events(&env), 0, "balance == threshold should not trigger alert");
+    assert_eq!(
+        count_alert_events(&env),
+        0,
+        "balance == threshold should not trigger alert"
+    );
 }


### PR DESCRIPTION
Closes #17
### Description

`set_alert_threshold` previously stored a value but had no reader, and balance changes from `stake`/`unstake` were never checked against the threshold. This PR completes the alert threshold feature by:

1. **Persisting the threshold** under `YieldDataKey::AlertThreshold` (already existed) and adding a `get_alert_threshold` read method.
2. **Checking balance against the threshold** after every `stake` and `unstake`, publishing an `AlertEvent` with severity `Critical` and kind `BalanceDrop` when the balance falls below the threshold.
3. **Adding comprehensive tests** covering event emission on breach, no event when not breached, exact-threshold boundary behavior, and no-alert-without-threshold.

### Changes

- **`contracts/staking/src/lib.rs`**:
  - Added `get_alert_threshold` public read method returning `Option<i128>`.
  - Added `check_balance_threshold` private helper that compares balance vs threshold and emits `alerts::AlertEvent`.
  - Wired the check into both `stake` and `unstake` after balance updates.

- **`contracts/staking/src/tests.rs`**:
  - 8 new tests covering alert threshold persistence, event emission on breach, no event when above threshold, exact-threshold boundary, and no-alert-without-threshold scenarios.

### Acceptance Criteria

- [x] `set_alert_threshold` persists a value readable via `get_alert_threshold`.
- [x] Crossing the threshold on stake/unstake publishes a distinct `AlertEvent` with topic `("ALERT", staker, asset)`.
- [x] Tests assert event emission on breach and no event when not breached.
- [x] `cargo test -p astraport-staking` passes (all 8 new tests pass; pre-existing `should_panic` crash on Windows is unrelated).